### PR TITLE
feat(compiler): support top level enums

### DIFF
--- a/compiler/lib/compiler_test.go
+++ b/compiler/lib/compiler_test.go
@@ -21,6 +21,7 @@ func Test(t *testing.T) {
 	assert.Error(t, c.CompileFile("validator_map_test.pconf"))
 	assert.NoError(t, c.CompileFile("validator_passing_test.pconf"))
 	assert.NoError(t, c.CompileFile("enum_test.pconf"))
+	assert.NoError(t, c.CompileFile("enum_top_test.pconf"))
 	assert.Error(t, c.CompileFile("enum_wrong_types_test.pconf"))
 	assert.NoError(t, c.CompileFile("multioutputs_test.mpconf"))
 	assert.NoError(t, c.CompileFile("include_pinc_test.pconf"))

--- a/compiler/lib/starlark_loader.go
+++ b/compiler/lib/starlark_loader.go
@@ -203,6 +203,9 @@ func (l *starlarkLoader) loadProto(modulePath string) (starlark.StringDict, erro
 	for _, message := range fileDescriptor.GetMessageTypes() {
 		globals[message.GetName()] = starproto.NewMessageType(message)
 	}
+	for _, enum := range fileDescriptor.GetEnumTypes() {
+		globals[enum.GetName()] = starproto.NewEnumType(enum)
+	}
 	return globals, nil
 }
 

--- a/compiler/lib/testdata/src/enum_test.pconf
+++ b/compiler/lib/testdata/src/enum_test.pconf
@@ -1,10 +1,16 @@
-load("test.proto", "MessageWithEnum")
+load("test.proto", "MessageWithEnum", "MessageWithExternalEnum", "TopLevelEnum")
 
 def main():
-    m=MessageWithEnum(e=MessageWithEnum.TestEnum.ONE)
+    m = MessageWithEnum(e=MessageWithEnum.TestEnum.ONE)
     if m.e == MessageWithEnum.TestEnum.TWO:
         fail("%s and %s should not match" % (m.e, MessageWithEnum.TestEnum.TWO))
     if m.e != MessageWithEnum.TestEnum.ONE:
         fail("%s and %s should match" % (m.e, MessageWithEnum.TestEnum.ONE))
+
+    m2 = MessageWithExternalEnum(e=TopLevelEnum.ONE)    
+    if m2.e == TopLevelEnum.TWO:
+        fail("%s and %s should not match" % (m2.e, TopLevelEnum.TWO))
+    if m2.e != TopLevelEnum.ONE:
+        fail("%s and %s should match" % (m2.e, TopLevelEnum.ONE))
 
     return m

--- a/compiler/lib/testdata/src/enum_test.pconf
+++ b/compiler/lib/testdata/src/enum_test.pconf
@@ -1,4 +1,4 @@
-load("test.proto", "MessageWithEnum", "MessageWithExternalEnum", "TopLevelEnum")
+load("test.proto", "MessageWithEnum")
 
 def main():
     m = MessageWithEnum(e=MessageWithEnum.TestEnum.ONE)
@@ -6,11 +6,5 @@ def main():
         fail("%s and %s should not match" % (m.e, MessageWithEnum.TestEnum.TWO))
     if m.e != MessageWithEnum.TestEnum.ONE:
         fail("%s and %s should match" % (m.e, MessageWithEnum.TestEnum.ONE))
-
-    m2 = MessageWithExternalEnum(e=TopLevelEnum.ONE)    
-    if m2.e == TopLevelEnum.TWO:
-        fail("%s and %s should not match" % (m2.e, TopLevelEnum.TWO))
-    if m2.e != TopLevelEnum.ONE:
-        fail("%s and %s should match" % (m2.e, TopLevelEnum.ONE))
 
     return m

--- a/compiler/lib/testdata/src/enum_top_test.pconf
+++ b/compiler/lib/testdata/src/enum_top_test.pconf
@@ -1,0 +1,11 @@
+
+load("test.proto", "MessageWithExternalEnum", "TopLevelEnum")
+
+def main():
+    m = MessageWithExternalEnum(e=TopLevelEnum.ONE)    
+    if m.e == TopLevelEnum.TWO:
+        fail("%s and %s should not match" % (m.e, TopLevelEnum.TWO))
+    if m.e != TopLevelEnum.ONE:
+        fail("%s and %s should match" % (m.e, TopLevelEnum.ONE))
+
+    return m

--- a/compiler/lib/testdata/src/test.proto
+++ b/compiler/lib/testdata/src/test.proto
@@ -27,6 +27,16 @@ message MessageWithEnum {
     TestEnum e = 1;
 }
 
+enum TopLevelEnum {
+    ZERO = 0;
+    ONE = 1;
+    TWO = 2;
+}
+
+message MessageWithExternalEnum {
+    TopLevelEnum e = 1;
+}
+
 message ValidateMe {
     string notempty = 1;
     map<string, string> validate_map = 2;

--- a/compiler/starproto/enum_type.go
+++ b/compiler/starproto/enum_type.go
@@ -12,6 +12,13 @@ type starProtoEnumType struct {
 	desc *desc.EnumDescriptor
 }
 
+func NewEnumType(desc *desc.EnumDescriptor) starlark.Value {
+	mt := &starProtoEnumType{
+		desc: desc,
+	}
+	return mt
+}
+
 func (t *starProtoEnumType) String() string {
 	return fmt.Sprintf("<proto.EnumType %s>", t.desc.GetName())
 }

--- a/compiler/starproto/message_type.go
+++ b/compiler/starproto/message_type.go
@@ -46,7 +46,7 @@ func (mt *starProtoMessageType) Name() string {
 func (mt *starProtoMessageType) Attr(attrName string) (starlark.Value, error) {
 	for _, enum := range mt.desc.GetNestedEnumTypes() {
 		if attrName == enum.GetName() {
-			return &starProtoEnumType{desc: enum}, nil
+			return NewEnumType(enum), nil
 		}
 	}
 


### PR DESCRIPTION
Protobufs allow enums to be defined outside of a message and it may
not be best practice however there are instances of common enums
shared amongst a lot of messages where having this defined outside
of a message definition is useful.