### PR TITLE
Issues-316

### DIFF
--- a/examples/grpc_clients/go_client/main.go
+++ b/examples/grpc_clients/go_client/main.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/protoconf/protoconf/examples/protoconf/src/crawler"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -30,7 +31,7 @@ func main() {
 
 func listenToChanges(path string) {
 	address := consts.AgentDefaultAddress
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("Error connecting to server address=%s err=%v", address, err)
 	}

--- a/examples/mutation/go_client/main.go
+++ b/examples/mutation/go_client/main.go
@@ -15,6 +15,7 @@ import (
 	pc "github.com/protoconf/protoconf/server/api/proto/v1"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -60,7 +61,7 @@ func mutate(path string, value descriptor.Message, scriptMetadata string) error 
 	request := &pc.ConfigMutationRequest{Path: path, Value: config, ScriptMetadata: scriptMetadata}
 
 	address := consts.ServerDefaultAddress
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("error connecting to server address=%s err=%s", address, err)
 	}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -150,7 +151,7 @@ func (e *Executor) Close() {
 }
 
 func getProtoconfClient(address string) (pc.ProtoconfServiceClient, *grpc.ClientConn) {
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("Error connecting to server address=%s err=%v", address, err)
 	}

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/protoconf/protoconf/utils"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var conn *grpc.ClientConn
@@ -158,7 +159,7 @@ func (c *cliCommand) Run(args []string) int {
 
 	log.Println(msg.String())
 	address := config.serverAddress
-	conn, err = grpc.Dial(address, grpc.WithInsecure())
+	conn, err = grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatal(fmt.Errorf("error connecting to server address=%s err=%s", address, err))
 	}

--- a/website/protoconf/docs/advanced-usage/mutation-service/grpc.mdx
+++ b/website/protoconf/docs/advanced-usage/mutation-service/grpc.mdx
@@ -16,11 +16,12 @@ import (
 	protoconf_value "github.com/protoconf/protoconf/datatypes/proto/v1"
 	server_config "myproject/v1" // replace with your actual import path
 	"google.golang.org/grpc"
+  "google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func main() {
-	cc, err := grpc.Dial(":4301", grpc.WithInsecure())
+	cc, err := grpc.Dial(":4301", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
 	}

--- a/website/protoconf/docs/consume-config-updates.mdx
+++ b/website/protoconf/docs/consume-config-updates.mdx
@@ -89,13 +89,14 @@ import (
     "log"
 
     "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
     "github.com/golang/protobuf/ptypes"
     pb "gen/go/protoconf/v1"
     mypb "gen/go/myproject/v1"
 )
 
 func main() {
-    conn, err := grpc.Dial("localhost:4300", grpc.WithInsecure())
+    conn, err := grpc.Dial("localhost:4300", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to connect: %v", err)
     }

--- a/website/protoconf/versioned_docs/version-0.1.7/advanced-usage/mutation-service/grpc.mdx
+++ b/website/protoconf/versioned_docs/version-0.1.7/advanced-usage/mutation-service/grpc.mdx
@@ -16,11 +16,12 @@ import (
 	protoconf_value "github.com/protoconf/protoconf/datatypes/proto/v1"
 	server_config "myproject/v1" // replace with your actual import path
 	"google.golang.org/grpc"
+  "google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func main() {
-	cc, err := grpc.Dial(":4301", grpc.WithInsecure())
+	cc, err := grpc.Dial(":4301", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
 	}

--- a/website/protoconf/versioned_docs/version-0.1.7/consume-config-updates.mdx
+++ b/website/protoconf/versioned_docs/version-0.1.7/consume-config-updates.mdx
@@ -89,13 +89,14 @@ import (
     "log"
 
     "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
     "github.com/golang/protobuf/ptypes"
     pb "gen/go/protoconf/v1"
     mypb "gen/go/myproject/v1"
 )
 
 func main() {
-    conn, err := grpc.Dial("localhost:4300", grpc.WithInsecure())
+    conn, err := grpc.Dial("localhost:4300", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to connect: %v", err)
     }


### PR DESCRIPTION
Replaced deprecated usage of grpc.WithInsecure() with grpc.WithTransportCredentials(insecure.NewCredentials()) Done for docs and examples