### PR TITLE
Remove deprecated use of ioutil (#330)

### DIFF
--- a/compiler/lib/compiler_test.go
+++ b/compiler/lib/compiler_test.go
@@ -1,7 +1,7 @@
 package lib
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -9,7 +9,7 @@ import (
 
 func Test(t *testing.T) {
 	c := NewCompiler("testdata", true)
-	dir, err := ioutil.TempDir("", "compiler_output")
+	dir, err := os.MkdirTemp("", "compiler_output")
 	if err != nil {
 		t.Fatal("cannot create tmpdir", err)
 	}

--- a/compiler/lib/filesystem.go
+++ b/compiler/lib/filesystem.go
@@ -1,10 +1,10 @@
+//go:build !js
 // +build !js
 
 package lib
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -28,5 +28,5 @@ func openFile(path string) (io.ReadCloser, error) {
 }
 
 func writeFile(filename string, bytes []byte) error {
-	return ioutil.WriteFile(filename, bytes, 0644)
+	return os.WriteFile(filename, bytes, 0644)
 }

--- a/compiler/lib/filesystem_js.go
+++ b/compiler/lib/filesystem_js.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall/js"
 )
@@ -24,7 +23,7 @@ func openFile(path string) (io.ReadCloser, error) {
 	if contents.IsNull() {
 		return nil, fmt.Errorf("error reading %s", path)
 	}
-	readCloser := ioutil.NopCloser(bytes.NewReader([]byte(contents.String())))
+	readCloser := io.NopCloser(bytes.NewReader([]byte(contents.String())))
 	return readCloser, nil
 }
 

--- a/compiler/lib/starlark_loader.go
+++ b/compiler/lib/starlark_loader.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"path"
 	"path/filepath"
@@ -147,7 +147,7 @@ func (l *starlarkLoader) loadMutable(modulePath string) (starlark.StringDict, er
 	}
 	defer configReader.Close()
 
-	jsonData, err := ioutil.ReadAll(configReader)
+	jsonData, err := io.ReadAll(configReader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading from mutable config file, file=%s, err=%s", filename, err)
 	}
@@ -172,7 +172,7 @@ func (l *starlarkLoader) loadMutable(modulePath string) (starlark.StringDict, er
 
 	protoconfValue := &pc.ProtoconfValue{}
 	um := jsonpb.Unmarshaler{AnyResolver: anyResolver}
-	if err = um.Unmarshal(ioutil.NopCloser(bytes.NewReader(jsonData)), protoconfValue); err != nil {
+	if err = um.Unmarshal(io.NopCloser(bytes.NewReader(jsonData)), protoconfValue); err != nil {
 		return nil, fmt.Errorf("error unmarshaling, err=%s", err)
 	}
 
@@ -223,7 +223,7 @@ func (l *starlarkLoader) loadStarlark(thread *starlark.Thread, modulePath string
 		return nil, err
 	}
 	defer reader.Close()
-	moduleSource, err := ioutil.ReadAll(reader)
+	moduleSource, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/exec/watcher.go
+++ b/exec/watcher.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -199,7 +198,7 @@ func (w *watcher) runWriteAction(ctx context.Context, action *exec_config.Action
 	if err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
-	err = ioutil.WriteFile(action.Path, bytesToWrite, 0644)
+	err = os.WriteFile(action.Path, bytesToWrite, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}

--- a/importers/importers_test.go
+++ b/importers/importers_test.go
@@ -1,7 +1,7 @@
 package importers
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/jhump/protoreflect/desc/builder"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImporters(t *testing.T) {
-	dir, err := ioutil.TempDir("", "generate_test")
+	dir, err := os.MkdirTemp("", "generate_test")
 	assert.NoError(t, err, "failed to create tmp folder")
 	i := NewImporter("master/package/v1/master.proto", dir)
 

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -131,7 +130,7 @@ func (s server) MutateConfig(ctx context.Context, in *protoconfmutation.ConfigMu
 		return nil, logError(fmt.Errorf("error creating output directory %s, err: %s", filepath.Dir(filename), err))
 	}
 
-	if err := ioutil.WriteFile(filename, []byte(jsonData), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(jsonData), 0644); err != nil {
 		return nil, logError(fmt.Errorf("error writing to file %s, err: %s", filename, err))
 	}
 


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.