### PR TITLE
feat: add `protoconf fmt` command to format starlark files

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -27,7 +27,7 @@ func (c *cliCommand) Run(args []string) int {
 		return 2
 	}
 	if err := RunAgent(context.Background(), c.config); err != nil {
-		slog.Default().Error("error", err)
+		slog.Default().Error("error running agent", "error", err)
 		return 1
 	}
 	return 0

--- a/cmd/protoconf/main.go
+++ b/cmd/protoconf/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/protoconf/protoconf/command"
 	"github.com/protoconf/protoconf/compiler"
 	"github.com/protoconf/protoconf/devserver"
+	protoconffmt "github.com/protoconf/protoconf/fmt"
 	"github.com/protoconf/protoconf/inserter"
 	"github.com/protoconf/protoconf/mod"
 	"github.com/protoconf/protoconf/mutate"
@@ -27,6 +28,7 @@ func main() {
 			"agent":     agent.Command,
 			"compile":   compiler.Command,
 			"devserver": devserver.Command,
+			"fmt":       protoconffmt.Command,
 			"insert":    inserter.Command,
 			"mutate":    mutate.Command,
 			"serve":     server.Command,

--- a/compiler/lib/module_service.go
+++ b/compiler/lib/module_service.go
@@ -63,7 +63,7 @@ func NewModuleService(protoconfRoot string) *ModuleService {
 func (m *ModuleService) getProtoconfPath() string {
 	path, err := filepath.Abs(m.Config.ProtoconfPath)
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error getting protoconf path", "error", err)
 		os.Exit(1)
 	}
 	return path

--- a/examples/mutation/go_client/main.go
+++ b/examples/mutation/go_client/main.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	if err := mutate(path, &pb.Crawler{HttpTimeout: 30, UserAgent: userAgent}, scriptMetadata); err != nil {
-		slog.Error("error", err)
+		slog.Error("mutation failed", "error", err)
 		os.Exit(1)
 	}
 

--- a/fmt/command.go
+++ b/fmt/command.go
@@ -1,0 +1,215 @@
+package fmt
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/build"
+	"github.com/mitchellh/cli"
+)
+
+// StarlarkExtensions contains the file extensions that should be formatted
+var StarlarkExtensions = []string{
+	".pinc",
+	".pconf",
+	".mpconf",
+	".proto-validator",
+	".star",
+}
+
+type cliCommand struct{}
+
+type cliConfig struct {
+	write bool
+	diff  bool
+	list  bool
+}
+
+func newFlagSet() (*flag.FlagSet, *cliConfig) {
+	flags := flag.NewFlagSet("", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintln(flags.Output(), "Usage: protoconf fmt [OPTION]... [path]...")
+		fmt.Fprintln(flags.Output(), "")
+		fmt.Fprintln(flags.Output(), "Format starlark files (.pinc, .pconf, .mpconf, .proto-validator, .star)")
+		fmt.Fprintln(flags.Output(), "")
+		fmt.Fprintln(flags.Output(), "If no paths are provided, formats all starlark files in the current directory recursively.")
+		fmt.Fprintln(flags.Output(), "")
+		flags.PrintDefaults()
+	}
+
+	config := &cliConfig{}
+	flags.BoolVar(&config.write, "w", false, "Write result to (source) file instead of stdout")
+	flags.BoolVar(&config.diff, "d", false, "Display diffs instead of rewriting files")
+	flags.BoolVar(&config.list, "l", false, "List files whose formatting differs from protoconf fmt's")
+
+	return flags, config
+}
+
+func (c *cliCommand) Run(args []string) int {
+	flags, config := newFlagSet()
+	flags.Parse(args)
+
+	paths := flags.Args()
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	hasErrors := false
+	for _, path := range paths {
+		if err := processPath(path, config); err != nil {
+			slog.Error("Error processing path", "path", path, "error", err)
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		return 1
+	}
+	return 0
+}
+
+func processPath(path string, config *cliConfig) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		return filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if isStarlarkFile(p) {
+				if err := formatFile(p, config); err != nil {
+					slog.Error("Error formatting file", "file", p, "error", err)
+				}
+			}
+			return nil
+		})
+	}
+
+	return formatFile(path, config)
+}
+
+func isStarlarkFile(path string) bool {
+	for _, ext := range StarlarkExtensions {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func formatFile(path string, config *cliConfig) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	// Parse the file using buildtools (treats it as a .bzl-like file)
+	f, err := build.ParseDefault(path, src)
+	if err != nil {
+		return fmt.Errorf("parsing file: %w", err)
+	}
+
+	// Format the file
+	formatted := build.Format(f)
+
+	// Check if the file is already formatted
+	if bytes.Equal(src, formatted) {
+		return nil
+	}
+
+	if config.list {
+		fmt.Println(path)
+		return nil
+	}
+
+	if config.diff {
+		diff := computeDiff(path, src, formatted)
+		fmt.Print(diff)
+		return nil
+	}
+
+	if config.write {
+		// Preserve original file permissions
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("getting file info: %w", err)
+		}
+		if err := os.WriteFile(path, formatted, info.Mode()); err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+		fmt.Println(path)
+		return nil
+	}
+
+	// Default: print to stdout
+	fmt.Print(string(formatted))
+	return nil
+}
+
+func computeDiff(path string, original, formatted []byte) string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("diff %s\n", path))
+	buf.WriteString(fmt.Sprintf("--- %s (original)\n", path))
+	buf.WriteString(fmt.Sprintf("+++ %s (formatted)\n", path))
+
+	origLines := strings.Split(string(original), "\n")
+	fmtLines := strings.Split(string(formatted), "\n")
+
+	// Simple line-by-line diff
+	maxLen := len(origLines)
+	if len(fmtLines) > maxLen {
+		maxLen = len(fmtLines)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var origLine, fmtLine string
+		if i < len(origLines) {
+			origLine = origLines[i]
+		}
+		if i < len(fmtLines) {
+			fmtLine = fmtLines[i]
+		}
+
+		if origLine != fmtLine {
+			if i < len(origLines) {
+				buf.WriteString(fmt.Sprintf("-%s\n", origLine))
+			}
+			if i < len(fmtLines) {
+				buf.WriteString(fmt.Sprintf("+%s\n", fmtLine))
+			}
+		}
+	}
+
+	return buf.String()
+}
+
+func (c *cliCommand) Help() string {
+	var b bytes.Buffer
+	b.WriteString(c.Synopsis())
+	b.WriteString("\n\n")
+	flags, _ := newFlagSet()
+	flags.SetOutput(&b)
+	flags.Usage()
+	return b.String()
+}
+
+func (c *cliCommand) Synopsis() string {
+	return "Format starlark configuration files"
+}
+
+// Command is a cli.CommandFactory
+func Command() (cli.Command, error) {
+	return &cliCommand{}, nil
+}

--- a/importers/wktbuilders/wktbuilders.go
+++ b/importers/wktbuilders/wktbuilders.go
@@ -17,12 +17,12 @@ var (
 func fromFile(fileName string) *builder.FileBuilder {
 	fileDesc, err := desc.LoadFileDescriptor(fileName)
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error loading file descriptor", "error", err)
 		os.Exit(1)
 	}
 	builder, err := builder.FromFile(fileDesc)
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error creating file builder", "error", err)
 		os.Exit(1)
 	}
 	return builder

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -115,7 +115,7 @@ func (c *cliCommand) Run(args []string) int {
 	}
 	wrap, err := desc.WrapMessage(messageType.Descriptor())
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error wrapping message", "error", err)
 		os.Exit(1)
 	}
 
@@ -146,7 +146,7 @@ func (c *cliCommand) Run(args []string) int {
 		case descriptorpb.FieldDescriptorProto_TYPE_BOOL:
 			b, e := strconv.ParseBool(ret[1])
 			if e != nil {
-				slog.Error("error", e)
+				slog.Error("error parsing bool", "error", e)
 				os.Exit(1)
 			}
 			setField(msg, ret[0], b, func(s interface{}) interface{} {
@@ -204,7 +204,7 @@ type typerFunc func(interface{}) interface{}
 func setNumeric(msg *dynamic.Message, key, val string, typer typerFunc) {
 	i, err := strconv.ParseInt(val, 0, 64)
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error parsing int", "error", err)
 		os.Exit(1)
 	}
 	setField(msg, key, i, typer)
@@ -213,7 +213,7 @@ func setNumeric(msg *dynamic.Message, key, val string, typer typerFunc) {
 func setFloat(msg *dynamic.Message, key, val string, typer typerFunc) {
 	i, err := strconv.ParseFloat(val, 64)
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error parsing float", "error", err)
 		os.Exit(1)
 	}
 	setField(msg, key, i, typer)
@@ -222,7 +222,7 @@ func setFloat(msg *dynamic.Message, key, val string, typer typerFunc) {
 func setField(msg *dynamic.Message, key string, val interface{}, typer typerFunc) {
 	err := msg.TrySetFieldByName(key, typer(val))
 	if err != nil {
-		slog.Error("error", err)
+		slog.Error("error setting field", "error", err)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -442,7 +442,7 @@ func (s *ProtoconfMutationServer) ReportProgress(ctx context.Context, in *protoc
 }
 
 func logError(err error) error {
-	slog.Error("error", err)
+	slog.Error("error occurred", "error", err)
 	return err
 }
 


### PR DESCRIPTION
Add a new `fmt` command that formats starlark configuration files
(.pinc, .pconf, .mpconf, .proto-validator, .star) using the
buildtools/build formatter.

Features:
- Format files in place with -w flag
- Show diff with -d flag
- List files that need formatting with -l flag
- Recursively process directories
- Default to stdout for formatted output