### PR TITLE
fix(ci): give codecov a 1% threshold so it stops failing on rounding noise

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -152,7 +152,8 @@ None yet.
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260901-vaj | Merge 5 stale security dependency bumps (grpc, x/net, go-git, go-getter, otel) + raise Go floor to 1.25.8 | 2026-09-01 | 1817300 | [260901-vaj-merge-5-stale-security-dependency-bumps-](./quick/260901-vaj-merge-5-stale-security-dependency-bumps-/) |
-| 260901-wom | CI hardening: enforce lint via trunk gate — Lint workflow (trunk + buf breaking), repaired trunk/buf configs, hardened go.yml, consolidated renovate.json | 2026-09-01 | 47b85cd | [260901-wom-ci-hardening-enforce-lint-via-trunk-gate](./quick/260901-wom-ci-hardening-enforce-lint-via-trunk-gate/) |
+| 260901-wom | CI hardening: Lint workflow (golangci-lint + buf breaking + actionlint), buf.yaml excludes, hardened go.yml, consolidated renovate.json. Trunk job dropped — its pinned tools had rotted upstream | 2026-09-01 | 74a193b | [260901-wom-ci-hardening-enforce-lint-via-trunk-gate](./quick/260901-wom-ci-hardening-enforce-lint-via-trunk-gate/) |
+| 260902-cov | Give codecov a 1% project threshold and mark patch informational, so codecov/project stops failing on rounding noise | 2026-09-02 | 3238abe | — |
 | 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
 
 ## Session Continuity

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,8 +5,8 @@ current_phase: 2
 current_phase_name: os.Exit Refactoring
 status: Milestone complete
 stopped_at: Quick task 260901-wom complete — Lint workflow + trunk/buf/go.yml/renovate hardening on ci/hardening
-last_updated: "2026-09-01T16:45:21.432Z"
-state_head: 47b85cdb5c7227b8c252aabe35744f0e123df37b
+last_updated: "2026-09-01T17:31:10.140Z"
+state_head: 3238abe063793889ae105fa56e72af45e1c88412
 progress:
   total_phases: 10
   completed_phases: 10
@@ -153,6 +153,7 @@ None yet.
 |---|-------------|------|--------|-----------|
 | 260901-vaj | Merge 5 stale security dependency bumps (grpc, x/net, go-git, go-getter, otel) + raise Go floor to 1.25.8 | 2026-09-01 | 1817300 | [260901-vaj-merge-5-stale-security-dependency-bumps-](./quick/260901-vaj-merge-5-stale-security-dependency-bumps-/) |
 | 260901-wom | CI hardening: enforce lint via trunk gate — Lint workflow (trunk + buf breaking), repaired trunk/buf configs, hardened go.yml, consolidated renovate.json | 2026-09-01 | 47b85cd | [260901-wom-ci-hardening-enforce-lint-via-trunk-gate](./quick/260901-wom-ci-hardening-enforce-lint-via-trunk-gate/) |
+| 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
 
 ## Session Continuity
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,24 @@
+# Generated protobuf code is excluded from coverage entirely.
 ignore:
   - "**/*.pb.go"
+
+coverage:
+  status:
+    # Without an explicit status block Codecov defaults to `threshold: 0%`, which
+    # fails the check on any decrease at all -- including the sub-percent drift
+    # you get from Go's per-run coverage rounding and from timing-sensitive tests
+    # taking different branches. That fired on #513, a pure dependency bump that
+    # changed no Go source. A 1% band absorbs the noise while still catching a
+    # real regression.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    # Patch coverage is advisory: it reports on the diff but does not block. A
+    # dependency bump or a config-only change has no coverable lines, and a
+    # blocking patch status turns those into red checks for no signal.
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
`codecov.yml` carried only an `ignore` list, so Codecov fell back to its default project status of `target: auto, threshold: 0%` — **any** decrease fails the check, including sub-percent drift from Go's per-run coverage rounding and from timing-sensitive tests taking different branches between runs.

That is what turned `codecov/project` red on #513, a pure dependency bump that changed no Go source at all.

- **project** — 1% band. Wide enough to absorb the noise, narrow enough to still catch a real regression.
- **patch** — marked `informational`. It still reports on the diff, but a dependency bump or config-only change has no coverable lines, and a blocking patch status makes those red for no signal.

Verified against https://codecov.io/validate, which parsed the file and echoed back the intended thresholds — no CI round-trip needed to confirm the syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3Q8zuirvV9rjkcYvBzxxz