### PR TITLE
fix(dummykv): fix two pubSub races behind the SubscribeForConfig flake

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -145,7 +145,6 @@ None yet.
 
 - Phase 9 (Unit Test Coverage) depends on Phase 2 (os.Exit Refactoring) so tests can test real error paths — plan Phase 9 only after Phase 2 is complete
 - Phase 10 (Integration Tests) depends on both Phase 6 (Auth) and Phase 9 (Unit Tests) — schedule last
-- `TestProtoconfKVAgentRollout_SubscribeForConfig` is a pre-existing flaky test (2–5 failures per 10 runs) — unsynchronised subscriber goroutines race the insert loop. Will make CI red at random until fixed. See quick task 260901-vaj deferred-items.
 
 ### Quick Tasks Completed
 
@@ -153,6 +152,7 @@ None yet.
 |---|-------------|------|--------|-----------|
 | 260901-vaj | Merge 5 stale security dependency bumps (grpc, x/net, go-git, go-getter, otel) + raise Go floor to 1.25.8 | 2026-09-01 | 1817300 | [260901-vaj-merge-5-stale-security-dependency-bumps-](./quick/260901-vaj-merge-5-stale-security-dependency-bumps-/) |
 | 260901-wom | CI hardening: Lint workflow (golangci-lint + buf breaking + actionlint), buf.yaml excludes, hardened go.yml, consolidated renovate.json. Trunk job dropped — its pinned tools had rotted upstream | 2026-09-01 | 74a193b | [260901-wom-ci-hardening-enforce-lint-via-trunk-gate](./quick/260901-wom-ci-hardening-enforce-lint-via-trunk-gate/) |
+| 260902-14f | Fix dummykv pubSub races — lost watcher registrations and duplicate delivery; TestProtoconfKVAgentRollout_SubscribeForConfig now 20/20 | 2026-09-02 | 807bf7b | [260902-14f-fix-dummykv-pubsub-registration-race-roo](./quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/) |
 | 260902-cov | Give codecov a 1% project threshold and mark patch informational, so codecov/project stops failing on rounding noise | 2026-09-02 | 3238abe | — |
 | 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
 

--- a/.planning/quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/260902-14f-PLAN.md
+++ b/.planning/quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/260902-14f-PLAN.md
@@ -1,0 +1,280 @@
+---
+phase: 260902-14f
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent/dummykv/dummykv.go
+  - agent/dummykv/dummykv_test.go
+  - agent/kv_agent_rollout_impl_test.go
+autonomous: true
+requirements: [QUICK-260902-14f]
+
+estimate:
+  tokens: 45000
+  raw_tokens: 30000
+  tasks: 3
+  confidence: low
+
+must_haves:
+  truths:
+    - "pubSub.Channel never drops a registration when called concurrently for the same key"
+    - "Every watcher registered before a Put receives that Put"
+    - "TestProtoconfKVAgentRollout_SubscribeForConfig passes 20/20 consecutive runs"
+    - "No subscriber goroutine calls t.Errorf after its parent test function has returned"
+  artifacts:
+    - "agent/dummykv/dummykv.go — topics is a plain map guarded by one sync.Mutex covering both Channel and Publish"
+    - "agent/dummykv/dummykv_test.go — TestWatch_ConcurrentSubscribersAllReceive, delivery-based, many trials, zero tolerated losses"
+    - "agent/kv_agent_rollout_impl_test.go — ready/done sync.WaitGroup barriers, no t.Run inside a goroutine"
+  key_links:
+    - "One mutex covers BOTH Channel and Publish — locking Channel alone still lets Publish iterate a slice that Channel is replacing"
+    - "ready.Wait() gates the insert loop; done.Wait() gates the parent subtest's return"
+---
+
+<objective>
+Kill the `TestProtoconfKVAgentRollout_SubscribeForConfig` flake at its root: an unguarded
+read-modify-write in `agent/dummykv`'s `pubSub.Channel` that silently drops watcher
+registrations when two goroutines subscribe to the same key concurrently (measured:
+36/500 trials lost a registration with only 3 concurrent subscribers).
+
+Purpose: the flake is a real product bug in a `store.Store` implementation, not a test
+ordering problem. `go test -race` does not flag it — the individual `sync.Map` operations
+are atomic, so this is a *logical* race, not a data race. It must be caught by asserting on
+delivery, not by `-race`.
+
+Output: mutex-guarded pubSub, a regression test that provably fails against the unfixed
+code, and a soundly synchronised rollout test harness. Three separate commits.
+</objective>
+
+<execution_context>
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/workflows/execute-plan.md
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+@agent/dummykv/dummykv.go
+@agent/dummykv/dummykv_test.go
+@agent/kv_agent_rollout_impl_test.go
+</context>
+
+<constraints>
+- Branch `fix/dummykv-pubsub-race` is already checked out. Do NOT create or switch branches.
+- Do NOT fix the flake by lengthening timeouts, adding retries, or adding sleeps. Do not
+  touch any existing `within:` duration or the `time.Sleep(time.Second * 2)` in the insert
+  loop. The fix is the lock plus real synchronisation.
+- `agent/dummykv` is labelled a test stub in CLAUDE.md but implements the valkeyrie
+  `store.Store` interface and self-registers via `valkeyrie.Register(StoreName, newStore)`.
+  Fix it as real code.
+- Three tasks, three commits, in order. The dummykv fix lands before the test changes.
+</constraints>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Guard pubSub with one mutex covering both Channel and Publish</name>
+  <files>agent/dummykv/dummykv.go</files>
+  <action>
+Replace the `pubSub.topics *sync.Map` field with a plain
+`map[string][]chan *store.KVPair` plus a `sync.Mutex` on the same struct, and take that
+mutex in BOTH `Channel` and `Publish`.
+
+Why the whole `sync.Map` goes rather than just adding a lock around it: `Channel` performs
+a Load, then appends, then Stores. Each `sync.Map` operation is individually atomic but the
+Load-to-Store sequence is not, so two goroutines subscribing to the same key can both read
+the old slice and both write, and one registration is silently discarded. That watcher is
+then absent from the snapshot `Publish` iterates and receives nothing, ever. `sync.Map`
+buys nothing once a lock is required, and keeping it would leave a reader thinking the type
+is doing the synchronising.
+
+The same mutex must cover `Publish`, not a second lock: `Publish` reads the slice for a key
+while `Channel` may be replacing it.
+
+`Channel` becomes: make the channel, lock, `p.topics[key] = append(p.topics[key], ch)`,
+unlock, return the channel.
+
+`Publish` becomes: lock (defer unlock), range the slice for `kv.Key`, and spawn the same
+per-channel delivery goroutine that exists today. Spawning goroutines under the lock is
+fine — the blocking send happens inside the spawned goroutine, not inside the critical
+section. Preserve the existing async unbuffered-send delivery semantics exactly; do not
+change them to buffered or synchronous sends, several existing tests depend on the current
+behaviour.
+
+`newPubSub` initialises the map literal. The Go floor is 1.25 so the range variable is
+already per-iteration; the closure may capture `ch` directly instead of taking it as a
+parameter.
+
+Also delete the `mux *sync.RWMutex` field on `Store` and its initialiser in `New` — it is
+assigned once and never read anywhere in the package, and leaving a dead mutex next to a
+real concurrency fix is actively misleading.
+
+Do not change `Store.Watch`, `Store.Put`, or any other method. In particular leave the
+`if current, err := s.Get(...)` initial-value delivery in `Watch` alone — Task 3 relies on
+it.
+  </action>
+  <verify>
+    <automated>go build ./... &amp;&amp; go vet ./agent/dummykv/ &amp;&amp; go test ./agent/dummykv/ -count=1</automated>
+    <automated>grep -c 'sync.Map' agent/dummykv/dummykv.go   # topics is no longer a sync.Map; s.store may still be one</automated>
+  </verify>
+  <done>`agent/dummykv/dummykv.go` compiles, `pubSub` holds a `sync.Mutex` plus a plain map, both `Channel` and `Publish` take that mutex, the dead `Store.mux` field is gone, and all pre-existing dummykv tests still pass.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Regression test that fails against the unfixed pubSub</name>
+  <files>agent/dummykv/dummykv_test.go</files>
+  <behavior>
+    - N goroutines call `Store.Watch` on the SAME not-yet-existing key, released together
+      from a single start gate so the calls genuinely overlap.
+    - After all N `Watch` calls have returned, a single `Put` on that key must be delivered
+      to all N channels. Zero tolerated losses.
+    - Repeated over many trials, because the per-trial loss rate on the unfixed code is a
+      few percent, not 100%.
+  </behavior>
+  <action>
+Add `TestWatch_ConcurrentSubscribersAllReceive` to `agent/dummykv/dummykv_test.go`.
+
+Assert on DELIVERY through the public `Watch`/`Put` surface, not on an internal
+registration count. Two reasons: `-race` cannot catch this class of bug so the assertion
+has to be behavioural, and a delivery test compiles unchanged against the pre-Task-1 code,
+which is what makes the red-proof below possible at all.
+
+Shape: an outer loop of 200 trials. Each trial builds a fresh store via the existing
+`newTestStore(t)` helper and picks a key that has not been written yet, so the
+initial-value path in `Watch` cannot mask a lost registration. Spawn 8 goroutines, each
+blocking on `<-start` (an unbuffered `chan struct{}` closed by the main goroutine) before
+calling `s.Watch`, and each storing its returned channel into its own index of a
+pre-sized slice so no additional synchronisation is needed. A `sync.WaitGroup` awaited
+after `close(start)` guarantees every `Watch` has returned before the `Put`. Then one
+`Put`, then receive from all 8 channels with a per-channel `select` against a 2-second
+`time.After`, failing the trial with `t.Fatalf` naming the trial index and watcher index on
+timeout.
+
+8 watchers and 200 trials: the measured loss rate is 7.2% per trial with only 3 concurrent
+subscribers, so 8 makes a loss near-certain within 200 trials on unfixed code, while the
+fixed code runs the whole loop in well under a second because the failure branch is never
+taken.
+
+Prove it is a real regression test by running it against the pre-fix file. Task 1 is
+already committed at this point, so the unfixed version is `HEAD~1`:
+
+    cp agent/dummykv/dummykv.go /tmp/dummykv.fixed.go
+    git show HEAD~1:agent/dummykv/dummykv.go > agent/dummykv/dummykv.go
+    go test ./agent/dummykv/ -run TestWatch_ConcurrentSubscribersAllReceive -count=1
+    # ^ MUST FAIL. If it passes, the test is not exercising the race — raise the
+    #   watcher count or the trial count until it fails, then re-check.
+    cp /tmp/dummykv.fixed.go agent/dummykv/dummykv.go
+    go test ./agent/dummykv/ -run TestWatch_ConcurrentSubscribersAllReceive -count=1
+    # ^ MUST PASS
+
+Record both outcomes in the SUMMARY. Confirm `git status` shows `agent/dummykv/dummykv.go`
+restored and unmodified before committing.
+  </action>
+  <verify>
+    <automated>go test ./agent/dummykv/ -run TestWatch_ConcurrentSubscribersAllReceive -count=5</automated>
+    <automated>go test ./agent/dummykv/ -race -count=1</automated>
+  </verify>
+  <done>The new test passes 5/5 against the fixed code, was observed FAILING against `HEAD~1:agent/dummykv/dummykv.go`, and `dummykv.go` is byte-identical to its committed state afterwards.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Synchronise the rollout test harness</name>
+  <files>agent/kv_agent_rollout_impl_test.go</files>
+  <action>
+Rewrite the `for _, tt := range tests` block at the bottom of
+`TestProtoconfKVAgentRollout_SubscribeForConfig` (roughly lines 155-191). Three independent
+defects, all inside the `t.Run(tt.name, ...)` closure:
+
+1. `t.Run(want.agentChannel, ...)` is called from inside a spawned goroutine, which is a
+   misuse of the testing package. Delete the nested `t.Run(want.agentChannel, ...)` and the
+   inner `t.Run(fmt.Sprint(i), ...)` entirely. Keep the assertions inline in the goroutine
+   and put `want.agentChannel` and the expectation index into every failure message so the
+   output still identifies which subscriber and which update failed. Drop the now-unused
+   `fmt` import if nothing else in the file needs it.
+
+2. Nothing gates "all subscribers subscribed" against "start inserting". Declare a
+   `var ready sync.WaitGroup` before the subscriber loop, `ready.Add(len(tt.args.want))`,
+   have each goroutine call `ready.Done()` once its `SubscribeForConfig` call has returned
+   (including on the error path, so a failed subscribe cannot deadlock the barrier), and
+   `ready.Wait()` immediately before the `for _, update := range tt.args.updates` loop.
+
+3. The parent closure returns as soon as the insert loop finishes, so subscriber goroutines
+   can still be running — and any `t.Errorf` they make after that point panics with "Log in
+   goroutine after test has completed". Declare a second `var done sync.WaitGroup`,
+   `done.Add(len(tt.args.want))`, `defer done.Done()` at the top of each goroutine, and
+   `done.Wait()` as the last statement of the `t.Run(tt.name, ...)` closure.
+
+While rewriting, also fix the ordering bug in the existing body: `recvCh(ctx, watcher)` is
+currently called before `assert.NoError(t, err)`, which would dereference a nil watcher on a
+subscribe error. Check the error first and return early if it is non-nil.
+
+Preserve unchanged: every `within:` duration, the `time.Sleep(time.Second * 2)` in the
+insert loop, the per-subscriber `context.WithCancel(context.Background())` and its
+`defer cancel()`, the `sleep, cancelSleep := context.WithTimeout(ctx, expect.within)`
+select, the `proto.Equal` assertion, and `recvCh` itself.
+
+On the ready barrier's guarantee, so a later reader does not "improve" it into a sleep: it
+proves the client-side stream exists before the first insert, not that the server handler
+has already reached `store.Watch`. The residual window is closed by the initial-value path
+in `dummykv.Store.Watch` — if a `Put` beats the server's `Watch`, the key now exists and
+`Get` delivers the current value to the new watcher. Add a short comment at `ready.Wait()`
+saying exactly that. What that barrier cannot survive is a server handler stalling for the
+full 2 seconds between inserts, which is a scheduling pathology, not a race. Record that
+ceiling as a `ponytail:` comment on the same line.
+  </action>
+  <verify>
+    <automated>go vet ./agent/ &amp;&amp; go test ./agent/ -run TestProtoconfKVAgentRollout_SubscribeForConfig -count=1 -timeout 5m</automated>
+    <automated>pass=0; for i in $(seq 1 20); do go test ./agent/ -run TestProtoconfKVAgentRollout_SubscribeForConfig -count=1 -timeout 5m >/dev/null 2>&amp;1 &amp;&amp; pass=$((pass+1)); done; echo "PASS RATE: $pass/20"</automated>
+  </verify>
+  <done>20/20 consecutive independent runs pass. Anything less than 20/20 is a FAILURE — report the real number, do not re-run until a green streak appears.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none introduced) | This change is internal concurrency control in an in-memory KV store. No new input parsing, no new network surface, no new dependencies, no package-manager installs. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-260902-14f-01 | Denial of Service | `pubSub.Publish` holds the mutex while spawning delivery goroutines | low | accept | Goroutine creation is non-blocking; the blocking unbuffered send happens inside the spawned goroutine, outside the critical section. Pre-existing behaviour, unchanged by this fix. |
+| T-260902-14f-02 | Denial of Service | `pubSub` delivery goroutines block forever if a watcher stops reading | low | accept | Pre-existing leak in a dev/test-path store, out of scope for a root-cause race fix. Do not expand scope to address it. |
+</threat_model>
+
+<verification>
+1. `go build ./...` — everything compiles.
+2. `go test ./agent/dummykv/ -race -count=1` — dummykv package green under race detector.
+3. Red-proof recorded for Task 2: the regression test FAILS against
+   `HEAD~1:agent/dummykv/dummykv.go` and PASSES against the fix.
+4. `pass=0; for i in $(seq 1 20); do go test ./agent/ -run TestProtoconfKVAgentRollout_SubscribeForConfig -count=1 -timeout 5m >/dev/null 2>&1 && pass=$((pass+1)); done; echo "PASS RATE: $pass/20"`
+   — must print `PASS RATE: 20/20`. Report the actual number honestly; a single green run
+   proves nothing about a 20-50% flake.
+5. `go test ./... -timeout 20m` — full suite, nothing else regressed.
+</verification>
+
+<success_criteria>
+- `pubSub.Channel` and `pubSub.Publish` are both guarded by one `sync.Mutex`; `topics` is a
+  plain map; the dead `Store.mux` field is deleted.
+- `TestWatch_ConcurrentSubscribersAllReceive` exists, asserts delivery to all concurrent
+  watchers across many trials with zero tolerated losses, and was demonstrated to fail
+  against the pre-fix code.
+- `TestProtoconfKVAgentRollout_SubscribeForConfig` has ready/done WaitGroup barriers, no
+  `t.Run` inside a goroutine, and error-checks `SubscribeForConfig` before using the watcher.
+- 20/20 consecutive runs of the previously-flaky test pass, with the rate reported.
+- `go test ./...` is green.
+- Three commits on `fix/dummykv-pubsub-race`. No branch was created or switched.
+- No timeout was lengthened, no retry added, no sleep added.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/260902-14f-SUMMARY.md` when done.
+Include the Task 2 red-proof result and the literal `PASS RATE: n/20` line.
+Update the `Blockers/Concerns` entry in `.planning/STATE.md` that currently lists this test
+as a known flake.
+</output>

--- a/.planning/quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/260902-14f-SUMMARY.md
+++ b/.planning/quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/260902-14f-SUMMARY.md
@@ -1,0 +1,183 @@
+---
+phase: 260902-14f
+plan: 01
+subsystem: testing
+tags: [go, sync, concurrency, dummykv, valkeyrie, race-condition]
+
+requires: []
+provides:
+  - "Mutex-guarded pubSub in agent/dummykv fixing a silent watcher-registration-loss race"
+  - "TestWatch_ConcurrentSubscribersAllReceive regression test, proven red against the pre-fix code"
+  - "Synchronized rollout test harness (ready/done WaitGroup barriers, no t.Run in a goroutine)"
+affects: [agent, dummykv, rollout-tests]
+
+actuals:
+  tokens: 1854
+  tasks: 3
+  commits: 3
+
+tech-stack:
+  added: []
+  patterns: ["sync.Mutex guarding a plain map instead of sync.Map when read-modify-write sequences are required"]
+
+key-files:
+  created: []
+  modified:
+    - agent/dummykv/dummykv.go
+    - agent/dummykv/dummykv_test.go
+    - agent/kv_agent_rollout_impl_test.go
+
+key-decisions:
+  - "Replaced pubSub.topics sync.Map with a plain map + sync.Mutex covering both Channel and Publish — sync.Map's individual atomicity does not cover Channel's load-append-store sequence"
+  - "Deleted the dead Store.mux *sync.RWMutex field (assigned once, never read)"
+  - "Regression test asserts delivery through the public Watch/Put surface, not internal registration counts, since -race cannot catch this logical race"
+  - "Rollout test harness rewritten with ready/done sync.WaitGroup barriers instead of t.Run inside a goroutine"
+
+patterns-established:
+  - "Delivery-based regression tests for logical (non-data) races that -race cannot detect: assert on the public API's observable behavior across many trials"
+
+requirements-completed: [QUICK-260902-14f]
+
+coverage:
+  - id: D1
+    description: "pubSub.Channel/Publish race fixed with a single mutex; dead Store.mux removed"
+    requirement: "QUICK-260902-14f"
+    verification:
+      - kind: unit
+        ref: "agent/dummykv/dummykv_test.go — full package suite (go test ./agent/dummykv/ -race -count=1)"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "TestWatch_ConcurrentSubscribersAllReceive added, proven to fail against the pre-fix dummykv.go and pass against the fix"
+    requirement: "QUICK-260902-14f"
+    verification:
+      - kind: unit
+        ref: "agent/dummykv/dummykv_test.go#TestWatch_ConcurrentSubscribersAllReceive"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "TestProtoconfKVAgentRollout_SubscribeForConfig harness synchronized with ready/done barriers; measured pass rate over 20 consecutive runs"
+    requirement: "QUICK-260902-14f"
+    verification:
+      - kind: unit
+        ref: "agent/kv_agent_rollout_impl_test.go#TestProtoconfKVAgentRollout_SubscribeForConfig — 20-run loop, PASS RATE: 18/20"
+        status: fail
+    human_judgment: true
+    rationale: "Measured 18/20, not the required 20/20. A residual, previously-masked race remains and is documented below; fixing it would require touching agent/dummykv/dummykv.go's Store.Watch/Store.Put, which this plan explicitly excludes from scope. A human must decide whether to accept this residual flake rate, expand scope to a follow-up plan, or reopen this plan's constraints."
+
+duration: 55min
+completed: 2026-09-02
+status: complete
+---
+
+# Phase 260902-14f: Fix dummykv pubSub registration race Summary
+
+**Mutex-guarded `agent/dummykv` pubSub kills the registration-loss race at its root; a delivery-based regression test proves it; the rollout test harness got real WaitGroup synchronization instead of goroutine-nested `t.Run` — but 20/20 was NOT achieved (measured 18/20) due to a second, previously-masked race this plan's constraints put out of scope.**
+
+## Performance
+
+- **Duration:** 55 min
+- **Started:** 2026-09-02T00:50:00Z
+- **Completed:** 2026-09-02T01:45:00Z
+- **Tasks:** 3
+- **Files modified:** 3
+
+## Accomplishments
+
+- `pubSub.topics` changed from `*sync.Map` to a plain `map[string][]chan *store.KVPair` guarded by one `sync.Mutex` covering both `Channel` and `Publish`, closing the load-append-store race that silently dropped watcher registrations (measured pre-fix: 36/500 trials lost a registration with only 3 concurrent subscribers).
+- Deleted the dead `Store.mux *sync.RWMutex` field (assigned once, never read anywhere).
+- Added `TestWatch_ConcurrentSubscribersAllReceive`: 200 trials x 8 goroutines calling `Watch` on the same not-yet-existing key from a shared start gate, asserting delivery of a subsequent `Put` to every watcher with zero tolerated losses.
+- Rewrote `TestProtoconfKVAgentRollout_SubscribeForConfig`'s subscriber loop: removed `t.Run` calls made from inside a spawned goroutine (a misuse of the testing package), added a `ready` `sync.WaitGroup` gating the insert loop on all `SubscribeForConfig` calls having returned, and a `done` `sync.WaitGroup` gating the parent subtest's return on all subscriber goroutines finishing — preventing both silent goroutine testing-API misuse and "Log in goroutine after test has completed" panics.
+- Fixed a nil-watcher-dereference ordering bug: the error from `SubscribeForConfig` is now checked before `recvCh(ctx, watcher)` is called.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Guard pubSub with one mutex covering both Channel and Publish** - `d378e14` (fix)
+2. **Task 2: Regression test that fails against the unfixed pubSub** - `ccb47fd` (test)
+3. **Task 3: Synchronise the rollout test harness** - `7f072b1` (test)
+
+**Plan metadata:** committed separately by the orchestrator (this executor does not commit docs artifacts per its constraints).
+
+## Files Created/Modified
+
+- `agent/dummykv/dummykv.go` - `pubSub.topics` is now a plain map guarded by `sync.Mutex`; `Channel` and `Publish` both take the lock; dead `Store.mux` field removed.
+- `agent/dummykv/dummykv_test.go` - Added `TestWatch_ConcurrentSubscribersAllReceive`.
+- `agent/kv_agent_rollout_impl_test.go` - Subscriber loop rewritten with `ready`/`done` WaitGroup barriers; nested `t.Run` calls removed; error-check-before-use ordering fixed.
+
+## Decisions Made
+
+- Removed `sync.Map` entirely for `pubSub.topics` rather than merely adding a lock around it: once a lock is required for the load-append-store sequence, `sync.Map` buys nothing and would mislead a future reader into thinking the type self-synchronizes.
+- Kept the async unbuffered-send delivery semantics in `Publish` exactly as before (goroutine spawned per channel, inside the locked section, blocking send happens outside it) — several existing tests depend on this.
+- Regression test asserts on delivery through the public `Watch`/`Put` surface rather than an internal registration count: `-race` cannot flag this class of bug (each individual `sync.Map` op was atomic; only the sequence was not), so the proof has to be behavioral, and a delivery-based test compiles unchanged against the pre-fix code — which is what made the mandated red-proof possible.
+- Rollout harness: kept every `within:` duration, the `time.Sleep(time.Second * 2)` insert-loop pacing, the per-subscriber `context.WithCancel`, the `select`-against-`context.WithTimeout` pattern, `proto.Equal`, and `recvCh` completely unchanged, per plan constraint. Only the goroutine-lifecycle and error-check-ordering bugs were fixed.
+
+## Deviations from Plan
+
+None in the sense of unplanned code changes — all three tasks were executed exactly as specified. The deviation is in the **outcome**, not the implementation: the plan's success criterion of `PASS RATE: 20/20` was not met.
+
+### Task 2 Red-Proof (required verification)
+
+Per the plan's revert-in-place procedure (Task 1 already committed, so `HEAD~1` was the unfixed dummykv.go):
+
+- **Against unfixed code (`HEAD~1:agent/dummykv/dummykv.go`):** `go test ./agent/dummykv/ -run TestWatch_ConcurrentSubscribersAllReceive -count=1` **FAILED**:
+  ```
+  --- FAIL: TestWatch_ConcurrentSubscribersAllReceive (2.00s)
+      dummykv_test.go:263: trial 0: watcher 1 never received the Put
+  FAIL
+  ```
+- **Restored to the fixed code:** `agent/dummykv/dummykv.go` was byte-identical to its committed state (`/usr/bin/diff` reported no differences, `git status --short` showed no modification) before proceeding, and the test **PASSED**: `ok github.com/protoconf/protoconf/agent/dummykv 0.284s`.
+
+This confirms `TestWatch_ConcurrentSubscribersAllReceive` is a genuine regression test for the Task 1 fix.
+
+### Task 3 Pass-Rate Measurement (required verification) — HONEST RESULT: 18/20, NOT 20/20
+
+The mandated 20-iteration loop was run (not a single `go test`, no timeout/retry/sleep changes):
+
+```
+run 1: PASS   run 6:  PASS   run 11: PASS   run 16: PASS
+run 2: FAIL   run 7:  PASS   run 12: PASS   run 17: PASS
+run 3: PASS   run 8:  PASS   run 13: PASS   run 18: PASS
+run 4: PASS   run 9:  PASS   run 14: PASS   run 19: PASS
+run 5: PASS   run 10: PASS   run 15: PASS   run 20: FAIL
+
+PASS RATE: 18/20
+```
+
+**This does not meet the plan's 20/20 success criterion. Reporting it as measured, not re-rolling for a green streak.**
+
+Both failures (`run 2`, `run 20`) show the identical failure signature — not the registration-loss bug Task 1 fixed, but a **different, previously-masked race**:
+
+```
+Messages: beta: expectation 1: expected "hello protoconf!", got "hello world!"
+```
+
+A subscriber's second expected update ("hello protoconf!") instead received a **second copy of the first update** ("hello world!"). Root cause, traced through `agent/kv_agent_rollout_impl.go` and `agent/dummykv/dummykv.go`:
+
+1. `SubscribeForConfig` (the gRPC handler) returns to the client as soon as the stream opens — it spawns `s.store.Watch(...)` asynchronously inside `watchKey`, in a background goroutine (`wg.Go(...)`). The client's `SubscribeForConfig` call returning therefore does **not** guarantee the server has reached `store.Watch` yet. This plan's `ready` barrier (Task 3) only proves the client-side stream exists — the plan's own text at `ready.Wait()` says exactly this, and states the residual window is "closed by the initial-value path in `dummykv.Store.Watch`".
+2. That assumption is only half right. `dummykv.Store.Put` stores the value synchronously (`s.store.Store(key, kv)`) and only *then* spawns `Publish` asynchronously (`go s.channels.Publish(kv)`). If a subscriber's `Watch` call — specifically its `Channel(key)` registration — lands in the narrow window **after** `Put`'s synchronous store but **before** `Put`'s async `Publish` goroutine actually runs, two things both fire for the same value: `Watch`'s own initial-value `Get()`-then-deliver path (which unconditionally sends the current value once a channel is registered, per its existing unconditional design that Task 1 was told not to touch) **and** the not-yet-run `Publish` goroutine, which by now sees the channel already registered in `topics` and sends the same value a second time. The result is one subscriber receiving "hello world!" twice instead of once, shifting its next expectation to "hello protoconf!" and failing the `proto.Equal` assertion.
+3. This is a distinct bug from the Task 1 registration-*loss* race (Task 1 fixed a missed delivery; this is a duplicate delivery), and it is **out of scope for this plan by explicit constraint**: "Do not change `Store.Watch`, `Store.Put`, or any other method... leave the `if current, err := s.Get(...)` initial-value delivery in `Watch` alone." Fixing it would require either touching those two methods (forbidden) or adding a sleep/retry/server-side ack mechanism in the test (also forbidden — "Do NOT lengthen any `within:` timeout, do not add retries, and do not add sleeps").
+
+**What was and was not fixed:** Task 1's mutex fix and Task 3's WaitGroup barriers are both real, verified improvements — the registration-loss bug is provably gone (Task 2's red-proof), and the harness no longer misuses `t.Run` from a goroutine or dereferences a nil watcher. What remains is a second, independent race that only became visible once the first one and the un-synchronized-goroutine bugs stopped masking it. It was not introduced by this plan's changes; it was always present in `dummykv.Store.Put`/`Watch`'s interaction, just statistically buried under the more frequent registration-loss failures this plan fixed.
+
+**Recommendation:** A follow-up quick task or plan is needed to close this second race, most likely by making `Store.Put`'s store-then-publish sequence atomic under the same `pubSub` mutex (or by having `Publish` and the initial-value `Get()` path share one lock so a channel registered mid-`Put` gets exactly one delivery, not zero or two). That requires touching `Store.Watch`/`Store.Put`, which is why it was left for a human decision rather than auto-fixed under Rule 1 here — this plan's constraints explicitly fenced those methods off, and silently overriding an explicit plan constraint is not this executor's call to make.
+
+## Issues Encountered
+
+- Local shell has `noclobber` and `cp` aliased to interactive mode, which silently no-op'd the first attempts at the red-proof's file-swap steps (`>` redirect and `cp` both failed without producing an error the first time, /the redirect printed "file exists" and `cp` prompted an unseen y/n). Diagnosed via `/usr/bin/diff` and `git status --short`, then used `>|` and `command cp -f` to force the overwrite/restore. No lasting effect — `git status --short` confirmed `agent/dummykv/dummykv.go` was clean before Task 2's commit.
+- Used `git stash -u` / `git stash pop` once during a vet-baseline check (to confirm two pre-existing `go vet` findings in unrelated files were not introduced by Task 3). This repo was explicitly NOT a worktree for this run, so the cross-worktree stash-collision risk documented in the executor's destructive-git-prohibition rule did not apply; the stash and pop both completed cleanly and `git status --short` confirmed the working tree was restored to the pre-stash state. Noting this for the record since `git stash` is normally avoided.
+
+## Next Phase Readiness
+
+- Tasks 1 and 2 (the pubSub mutex fix and its regression test) are solid and ready to rely on — `go test ./agent/dummykv/ -race -count=1` is green, and the fix is proven against the pre-fix code.
+- Task 3's harness improvements (no `t.Run` in a goroutine, no nil-watcher dereference, real barriers) are also solid, but `TestProtoconfKVAgentRollout_SubscribeForConfig` is **still flaky** (measured 18/20) due to the second race documented above. **CI will still go red at random on this test** until that second race is addressed. `.planning/STATE.md`'s Blockers/Concerns entry is being updated to reflect the new, narrower root cause rather than being cleared.
+- `go test ./... -timeout 20m` was green on this run (full suite, one pass) — no other package regressed.
+
+---
+*Phase: 260902-14f*
+*Completed: 2026-09-02*
+
+## Self-Check: PASSED
+
+All three commits (`d378e14`, `ccb47fd`, `7f072b1`) confirmed in `git log --oneline --all`. All modified files confirmed present on disk.

--- a/agent/dummykv/dummykv.go
+++ b/agent/dummykv/dummykv.go
@@ -73,6 +73,14 @@ func (p *pubSub) Channel(key string) chan *store.KVPair {
 type Store struct {
 	channels *pubSub
 	store    *sync.Map
+	// mu orders Put's (store value, then publish) against Watch's (register
+	// channel, then read current value). Each pair must be atomic with respect
+	// to the other, or a subscriber sees the same value twice: it registers,
+	// Put stores the value, the subscriber's Get now finds it and delivers,
+	// and Put's Publish then delivers the identical value again.
+	//
+	// Held as a pointer so Store's value receivers do not copy a lock.
+	mu *sync.Mutex
 }
 
 // New creates a new Example client.
@@ -81,14 +89,19 @@ func New(ctx context.Context, endpoints []string, options *Config) (*Store, erro
 	return &Store{
 		channels: newPubSub(),
 		store:    &sync.Map{},
+		mu:       &sync.Mutex{},
 	}, nil
 }
 
 // Put a value at the specified key.
 func (s *Store) Put(ctx context.Context, key string, value []byte, opts *store.WriteOptions) error {
 	kv := &store.KVPair{Key: key, Value: value}
+	s.mu.Lock()
 	s.store.Store(key, kv)
-	go s.channels.Publish(kv)
+	// Publish under the same lock as the store write. It only spawns the
+	// per-subscriber sends, so this does not block on slow readers.
+	s.channels.Publish(kv)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -117,9 +130,17 @@ func (s Store) Exists(ctx context.Context, key string, opts *store.ReadOptions) 
 
 // Watch for changes on a key.
 func (s Store) Watch(ctx context.Context, key string, opts *store.ReadOptions) (<-chan *store.KVPair, error) {
+	// Registering and reading the current value must happen together: either
+	// this whole section runs before a concurrent Put (key absent, so no
+	// initial delivery, and Put's Publish reaches us) or entirely after it
+	// (key present, so we deliver it once, and Publish has already run without
+	// us). Split them and both paths can fire for the same value.
+	s.mu.Lock()
 	ch := s.channels.Channel(key)
+	current, err := s.Get(ctx, key, opts)
+	s.mu.Unlock()
 
-	if current, err := s.Get(ctx, key, opts); err == nil {
+	if err == nil && current != nil {
 		go func(ch chan *store.KVPair) {
 			ch <- current
 		}(ch)

--- a/agent/dummykv/dummykv.go
+++ b/agent/dummykv/dummykv.go
@@ -34,41 +34,37 @@ func newStore(ctx context.Context, endpoints []string, options valkeyrie.Config)
 	return New(ctx, endpoints, cfg)
 }
 
+// topics is guarded by mu: Channel performs a read-modify-write (load,
+// append, store) that is not safe under sync.Map alone — two goroutines
+// subscribing to the same key concurrently can both read the old slice and
+// both write, silently dropping one registration. Publish takes the same
+// mutex so it never iterates a slice that Channel is mid-replace on.
 type pubSub struct {
-	topics *sync.Map
+	mu     sync.Mutex
+	topics map[string][]chan *store.KVPair
 }
 
 func newPubSub() *pubSub {
 	return &pubSub{
-		topics: &sync.Map{},
+		topics: map[string][]chan *store.KVPair{},
 	}
 }
 
 func (p *pubSub) Publish(kv *store.KVPair) {
-	result, ok := p.topics.Load(kv.Key)
-	if ok {
-		switch x := result.(type) {
-		case []chan *store.KVPair:
-			for _, ch := range x {
-				go func(ch chan *store.KVPair) {
-					ch <- kv
-				}(ch)
-			}
-		}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, ch := range p.topics[kv.Key] {
+		go func(ch chan *store.KVPair) {
+			ch <- kv
+		}(ch)
 	}
 }
 
 func (p *pubSub) Channel(key string) chan *store.KVPair {
 	ch := make(chan *store.KVPair)
-	arr := []chan *store.KVPair{ch}
-	result, ok := p.topics.Load(key)
-	if ok {
-		switch x := result.(type) {
-		case []chan *store.KVPair:
-			arr = append(arr, x...)
-		}
-	}
-	p.topics.Store(key, arr)
+	p.mu.Lock()
+	p.topics[key] = append(p.topics[key], ch)
+	p.mu.Unlock()
 	return ch
 }
 
@@ -77,7 +73,6 @@ func (p *pubSub) Channel(key string) chan *store.KVPair {
 type Store struct {
 	channels *pubSub
 	store    *sync.Map
-	mux      *sync.RWMutex
 }
 
 // New creates a new Example client.
@@ -86,7 +81,6 @@ func New(ctx context.Context, endpoints []string, options *Config) (*Store, erro
 	return &Store{
 		channels: newPubSub(),
 		store:    &sync.Map{},
-		mux:      &sync.RWMutex{},
 	}, nil
 }
 

--- a/agent/dummykv/dummykv_test.go
+++ b/agent/dummykv/dummykv_test.go
@@ -2,6 +2,8 @@ package dummykv
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -217,6 +219,51 @@ func TestPut_MultipleTimes(t *testing.T) {
 	pair, err := s.Get(ctx, key, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("v3"), pair.Value)
+}
+
+// TestWatch_ConcurrentSubscribersAllReceive asserts that when N goroutines
+// call Watch on the same not-yet-existing key concurrently, every one of
+// them ends up registered and receives a subsequent Put. This is a
+// delivery-based assertion through the public Watch/Put surface rather than
+// an internal registration count, both because -race cannot catch this
+// class of logical race (each individual sync.Map op is atomic) and because
+// a delivery test compiles unchanged against the pre-fix pubSub.
+func TestWatch_ConcurrentSubscribersAllReceive(t *testing.T) {
+	const trials = 200
+	const watchers = 8
+
+	for trial := 0; trial < trials; trial++ {
+		s := newTestStore(t)
+		key := fmt.Sprintf("concurrent-key-%d", trial)
+
+		start := make(chan struct{})
+		chans := make([]<-chan *store.KVPair, watchers)
+		var wg sync.WaitGroup
+		wg.Add(watchers)
+		for i := 0; i < watchers; i++ {
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				ch, err := s.Watch(context.Background(), key, nil)
+				require.NoError(t, err)
+				chans[i] = ch
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		err := s.Put(context.Background(), key, []byte("value"), nil)
+		require.NoError(t, err)
+
+		for i, ch := range chans {
+			select {
+			case kv := <-ch:
+				require.NotNil(t, kv)
+			case <-time.After(2 * time.Second):
+				t.Fatalf("trial %d: watcher %d never received the Put", trial, i)
+			}
+		}
+	}
 }
 
 func TestGet_WithWriteOptions(t *testing.T) {

--- a/agent/dummykv/dummykv_test.go
+++ b/agent/dummykv/dummykv_test.go
@@ -277,3 +277,56 @@ func TestGet_WithWriteOptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("opts-val"), pair.Value)
 }
+
+// TestWatch_NoDuplicateDeliveryRacingPut asserts that a subscriber racing a
+// concurrent Put receives that value exactly once.
+//
+// Watch registers a channel and then reads the current value; Put stores the
+// value and then publishes it. If those two pairs are not atomic with respect
+// to each other, this interleaving delivers the same value twice:
+//
+//	watcher: Channel(key)          -- registered
+//	putter:  store.Store(key, kv)  -- value now visible
+//	watcher: Get(key)              -- finds it, delivers  (#1)
+//	putter:  Publish(kv)           -- delivers again      (#2)
+//
+// A duplicate is not cosmetic: a subscriber that expects a sequence of updates
+// consumes the repeat in place of the next one and then stalls, which is how
+// this surfaced as a flake in TestProtoconfKVAgentRollout_SubscribeForConfig.
+func TestWatch_NoDuplicateDeliveryRacingPut(t *testing.T) {
+	const trials = 300
+
+	for i := 0; i < trials; i++ {
+		ctx := context.Background()
+		s, err := New(ctx, nil, &Config{})
+		require.NoError(t, err)
+
+		key := "racing-key"
+		var start sync.WaitGroup
+		start.Add(1)
+
+		// Put races Watch, released together to maximise the overlap.
+		go func() {
+			start.Wait()
+			_ = s.Put(ctx, key, []byte("v"), nil)
+		}()
+
+		start.Done()
+		ch, err := s.Watch(ctx, key, &store.ReadOptions{})
+		require.NoError(t, err)
+
+		// Exactly one delivery: take the first, then assert nothing else
+		// arrives within a short grace period.
+		select {
+		case first := <-ch:
+			require.NotNil(t, first, "trial %d: received a nil KVPair", i)
+			select {
+			case dup := <-ch:
+				t.Fatalf("trial %d: value delivered twice (second delivery: %q)", i, dup.Value)
+			case <-time.After(20 * time.Millisecond):
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("trial %d: no delivery at all -- the watcher registration was lost", i)
+		}
+	}
+}

--- a/agent/kv_agent_rollout_impl_test.go
+++ b/agent/kv_agent_rollout_impl_test.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"context"
-	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -155,38 +155,54 @@ func TestProtoconfKVAgentRollout_SubscribeForConfig(t *testing.T) {
 	for _, tt := range tests {
 		kvStore.DeleteTree(ctx, "/")
 		t.Run(tt.name, func(t *testing.T) {
+			var ready sync.WaitGroup
+			var done sync.WaitGroup
+			ready.Add(len(tt.args.want))
+			done.Add(len(tt.args.want))
 			for _, wantResults := range tt.args.want {
 				go func(want *want) {
-					t.Run(want.agentChannel, func(t *testing.T) {
-						ctx, cancel := context.WithCancel(context.Background())
-						defer cancel()
-						watcher, err := want.agentClient.SubscribeForConfig(ctx, want.request)
-						configCh := recvCh(ctx, watcher)
-						assert.NoError(t, err)
-						for i, expect := range want.expects {
-							t.Run(fmt.Sprint(i), func(t *testing.T) {
-								sleep, cancelSleep := context.WithTimeout(ctx, expect.within)
-								defer cancelSleep()
-								select {
-								case <-sleep.Done():
-									err := context.Cause(ctx)
-									assert.NoError(t, err)
-									t.Errorf("timeout waiting for update")
-									cancel()
-									return
-								case item := <-configCh:
-									assert.Truef(t, proto.Equal(expect.update, item), "expected \n%s, got \n%s", expect.update, item)
-									cancelSleep()
-								}
-							})
+					defer done.Done()
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					watcher, err := want.agentClient.SubscribeForConfig(ctx, want.request)
+					if !assert.NoErrorf(t, err, "%s: subscribe failed", want.agentChannel) {
+						ready.Done()
+						return
+					}
+					configCh := recvCh(ctx, watcher)
+					ready.Done()
+					for i, expect := range want.expects {
+						sleep, cancelSleep := context.WithTimeout(ctx, expect.within)
+						select {
+						case <-sleep.Done():
+							err := context.Cause(ctx)
+							assert.NoErrorf(t, err, "%s: expectation %d", want.agentChannel, i)
+							t.Errorf("%s: expectation %d: timeout waiting for update", want.agentChannel, i)
+							cancelSleep()
+							cancel()
+							return
+						case item := <-configCh:
+							assert.Truef(t, proto.Equal(expect.update, item), "%s: expectation %d: expected \n%s, got \n%s", want.agentChannel, i, expect.update, item)
+							cancelSleep()
 						}
-					})
+					}
 				}(wantResults)
 			}
+			// ready.Wait() proves the client-side stream exists before the first
+			// insert, not that the server handler has already reached
+			// store.Watch. The residual window is closed by the initial-value
+			// path in dummykv.Store.Watch — if a Put beats the server's Watch,
+			// the key now exists and Get delivers the current value to the new
+			// watcher.
+			// ponytail: this barrier cannot survive a server handler stalling
+			// for the full 2s between inserts (a scheduling pathology, not a
+			// race) — upgrade to a server-side ack if that ever proves flaky.
+			ready.Wait()
 			for _, update := range tt.args.updates {
 				assert.NoError(t, inserter.InsertConfig(update.configName, update.protoconfValue, update.metadata))
 				time.Sleep(time.Second * 2)
 			}
+			done.Wait()
 		})
 	}
 }


### PR DESCRIPTION
`TestProtoconfKVAgentRollout_SubscribeForConfig` failed 2/10 to 5/10 runs. It turned out not to be a test problem at all — `agent/dummykv` had **two** distinct races, both of which silently drop or corrupt config delivery to a subscriber.

## Race 1 — lost watcher registrations

`pubSub.Channel` did an unguarded read-modify-write on a `sync.Map`:

```go
result, ok := p.topics.Load(key)   // read
...
p.topics.Store(key, arr)           // modify-write
```

Individual `sync.Map` operations are atomic; the Load→Store sequence is not. Two goroutines subscribing to the **same key** concurrently could both read the old slice and both write it back, silently discarding one registration. That subscriber was then absent from `Publish`'s snapshot and received nothing, ever.

Measured before the fix with a probe registering 3 watchers on one key: **36/500 trials (7.2%) lost at least one registration.**

`topics` is now a plain map under one mutex held by both `Channel` and `Publish` — `sync.Map` buys nothing once a lock is mandatory, and a `Channel`-only lock would still let `Publish` iterate a slice mid-replace.

## Race 2 — duplicate delivery

Fixing race 1 moved the pass rate to 18/20, not 20/20. The remaining two failures shared one signature: a subscriber received the *first* update twice instead of the first then the second.

`Put` stored the value then published it; `Watch` registered a channel then read the current value. Neither pair was atomic against the other:

```
watcher: Channel(key)          -- registered
putter:  store.Store(key, kv)  -- value now visible
watcher: Get(key)              -- finds it, delivers  (#1)
putter:  Publish(kv)           -- delivers again      (#2)
```

The duplicate isn't cosmetic. A subscriber expecting a sequence consumes the repeat in place of the next update, then stalls waiting for one it has effectively skipped — which is why this presented as "first update twice" rather than as an obvious duplicate.

A store-level mutex now covers both pairs, so a watcher either registers wholly before a `Put` (key absent, no initial delivery, `Publish` reaches it) or wholly after (key present, delivered once, `Publish` already ran without it). Exactly one delivery either way. It's a pointer field so `Store`'s existing value receivers don't copy a lock and become new `go vet` findings.

## Test harness

`agent/kv_agent_rollout_impl_test.go` was independently unsound and is fixed in its own commit: `t.Run` was being called from inside a spawned goroutine; the parent `t.Run` closure returned as soon as the insert loop finished without ever waiting for the subscriber goroutines; and `recvCh(ctx, watcher)` ran *before* `assert.NoError(t, err)`, so a failed subscribe would nil-deref. Now uses `ready`/`done` `WaitGroup` barriers.

No `within:` timeout was lengthened, no retries added, no sleeps inserted.

## Verification

- **`TestProtoconfKVAgentRollout_SubscribeForConfig`: 20/20**, measured with a real 20-trial loop, not a single green run.
- Both regression tests were proven red against the unfixed code before being accepted. `TestWatch_ConcurrentSubscribersAllReceive` fails at `HEAD~1` with *"watcher 1 never received the Put"*; `TestWatch_NoDuplicateDeliveryRacingPut` fails with *"trial 13: value delivered twice"*.
- Note `go test -race` does **not** catch either bug — the individual `sync.Map` operations are atomic, so these are logical races. The tests assert on delivery through the public surface instead.
- Full `go test ./...` green; `go vet ./agent/dummykv/` clean.

## Why this matters beyond CI

`agent/dummykv` implements the valkeyrie `store.Store` interface and is wired into the devserver path. A dropped registration means a subscriber that silently never receives config updates — the failure mode CI was showing you, in miniature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3Q8zuirvV9rjkcYvBzxxz
