### PR TITLE
fix(inserter): resolve Any types when marshaling config.json

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -155,6 +155,7 @@ None yet.
 | 260902-14f | Fix dummykv pubSub races — lost watcher registrations and duplicate delivery; TestProtoconfKVAgentRollout_SubscribeForConfig now 20/20 | 2026-09-02 | 807bf7b | [260902-14f-fix-dummykv-pubsub-registration-race-roo](./quick/260902-14f-fix-dummykv-pubsub-registration-race-roo/) |
 | 260902-cov | Give codecov a 1% project threshold and mark patch informational, so codecov/project stops failing on rounding noise | 2026-09-02 | 3238abe | — |
 | 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
+| 260902-eie | Resolve google.protobuf.Any types when the inserter marshals config.json (backport of upstream PR #496) | 2026-09-02 | 841ca1b | [260902-eie-fix-any-resolution-in-inserter-json-mars](./quick/260902-eie-fix-any-resolution-in-inserter-json-mars/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260902-eie-fix-any-resolution-in-inserter-json-mars/260902-eie-PLAN.md
+++ b/.planning/quick/260902-eie-fix-any-resolution-in-inserter-json-mars/260902-eie-PLAN.md
@@ -1,0 +1,199 @@
+---
+phase: quick-260902-eie
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - inserter/inserter.go
+  - inserter/inserter_test.go
+autonomous: true
+requirements: [QUICK-260902-EIE]
+
+estimate:
+  tokens: 26000
+  raw_tokens: 13000
+  tasks: 2
+  confidence: low
+
+must_haves:
+  truths:
+    - "Inserting a materialized config whose message embeds a populated google.protobuf.Any of a user-defined type succeeds instead of aborting the whole insert."
+    - "The config.json written to the KV store contains the resolved Any payload (type URL plus inner fields) for singular, repeated, and map Any fields."
+    - "go test ./inserter/... and go build ./... both pass."
+  artifacts:
+    - inserter/inserter.go
+    - inserter/inserter_test.go
+  key_links:
+    - "XXXinsertVersion's config.json protojson.Marshal must use i.parser.LocalResolver, the same resolver parser.ReadConfig already uses on the read side."
+---
+
+<objective>
+Fix the missing `Resolver` on the config.json `protojson.Marshal` in
+`(*ProtoconfInserter).XXXinsertVersion`, so materialized configs containing
+`google.protobuf.Any` values of user-defined types can be inserted. Backport of the
+Any-resolution part of upstream PR #496 only.
+
+Purpose: today any config built with the `any.new()` Starlark builtin fails to insert entirely —
+protojson falls back to `protoregistry.GlobalTypes`, which has never heard of the user's protos.
+Output: a one-line production fix plus a regression test that fails without it.
+</objective>
+
+<execution_context>
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/workflows/execute-plan.md
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+@inserter/inserter.go
+@inserter/inserter_test.go
+</context>
+
+<prior_investigation>
+The planner reproduced the bug and validated the fix against the real code before writing this
+plan. The executor does not need to rediscover any of the following.
+
+**1. The bug reproduces with an EXISTING fixture — no new proto surface is needed.**
+
+`utils/testdata/small/materialized_config/field_type_any_test.materialized_JSON` (produced by
+`utils/testdata/small/src/field_type_any_test.pconf` via `any.new()`) already carries all three
+Any shapes: singular `anyField`, `anyRepeated`, and `anyMap`. Every inner Any is
+`type.googleapis.com/test.v1.TestMessage`, declared in `utils/testdata/small/src/test.proto`,
+which has no generated `.pb.go` and therefore exists ONLY in the parser's `LocalResolver`. That
+is exactly the condition the bug needs. `testdata.SmallTestDir()` — already used throughout
+`inserter/inserter_test.go` — materializes it into a temp git repo.
+
+**2. Observed failure on today's `main`:**
+
+```
+proto: google.protobuf.Any: unable to resolve "type.googleapis.com/test.v1.TestMessage": not found
+error marshaling ProtoconfValue to json, value=proto_file:"test.proto" ...
+```
+
+**3. Observed output AFTER applying the fix** (all three Any shapes serialize):
+
+```
+{
+  "stringValue": "recovered_from_any",
+  "anyField":    { "@type": "type.googleapis.com/test.v1.TestMessage", "stringValue": "test_any" },
+  "anyRepeated": [ { "@type": "...TestMessage", "stringValue": "test_any_repeated" } ],
+  "anyMap":      { "hello": { "@type": "...TestMessage", "stringValue": "test_any_map" } }
+}
+```
+
+**4. Sibling-call-site audit — already performed repo-wide. Result: `inserter.go:379` is the
+only gap. Do not touch anything else.**
+
+| Call site | Message marshaled | Verdict |
+|---|---|---|
+| `inserter/inserter.go:379` | `dynamicpb` built from `LocalResolver` — carries the user's config | **THE FIX.** Only site missing a resolver on a user-typed path |
+| `inserter/inserter.go:308` | `*protoconf_pb.ProtoconfValue_ConfigRollout` | **Leave alone.** Generated Go type in GlobalTypes; fields are only Duration / Timestamp / scalars / `map<string,string>`. No Any reachable |
+| `inserter/inserter.go:390` | `*protoconf_pb.Metadata` | **Leave alone.** Generated Go type in GlobalTypes; strings + Timestamps only. No Any reachable |
+| `server/server.go:416` | user value | Already passes `Resolver:` — correct, out of scope |
+| `compiler/lib/compiler.go:294` | `ProtoconfValue` | Already passes `Resolver: c.parser.LocalResolver` — correct, out of scope |
+| `compiler/lib/module_service.go:202` | module lock head | protoconf-owned, no Any. Correct as-is, out of scope |
+| `compiler/lib/parser/parser.go` `ReadConfig` | read side | Already passes `Resolver: p.LocalResolver` — this plan is the write side catching up |
+
+The inserter was the last holdout. This is the root-cause fix, not a symptom patch.
+</prior_investigation>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: Pass LocalResolver to the config.json protojson.Marshal</name>
+  <files>inserter/inserter.go</files>
+  <action>
+In `(*ProtoconfInserter).XXXinsertVersion`, at the "Writing config json" step (currently line
+379), add `Resolver: i.parser.LocalResolver` to the `protojson.MarshalOptions` literal that
+marshals the `new` dynamicpb message, so it reads
+`protojson.MarshalOptions{Multiline: true, Resolver: i.parser.LocalResolver}.Marshal(new)`.
+
+This is the entire production change. Do NOT add a resolver to the two sibling marshals in this
+same file (the rollout one a few lines above at 308, and the metadata one immediately below at
+390) — both marshal generated protoconf-owned Go types that are registered in
+`protoregistry.GlobalTypes` and whose field sets cannot reach a `google.protobuf.Any`. The
+repo-wide audit in the prior_investigation section is authoritative; do not re-audit and do not widen
+the diff. Do NOT run `go generate` and do NOT touch any `.pb.go` file — no proto change is
+needed. Do NOT pull in any other part of upstream PR #496 (etcd health check, GetConfig RPC,
+TLS, OTEL toggles are separate scheduled PRs).
+  </action>
+  <verify>
+    <automated>go build ./... && grep -v '^[[:space:]]*//' inserter/inserter.go | grep -c 'Resolver: i.parser.LocalResolver' | grep -qx 1 && go test ./inserter/... -count=1</automated>
+  </verify>
+  <done>`inserter/inserter.go` contains the resolver on exactly one marshal — the config-json one — and neither sibling marshal gained it (the count-is-exactly-1 gate is what proves the rollout and metadata marshals were left alone); `go build ./...` and `go test ./inserter/... -count=1` pass; `git diff --stat` shows one changed file and one changed line.</done>
+  <reversibility rating="reversible">One-line change to marshal options; revert is a single-line edit.</reversibility>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Regression test proving Any values survive the config.json write</name>
+  <files>inserter/inserter_test.go</files>
+  <behavior>
+    - Inserting `field_type_any_test.materialized_JSON` returns no error (today it returns `unable to resolve "type.googleapis.com/test.v1.TestMessage": not found`).
+    - The KV key `field_type_any_test/config.json` exists and its value mentions the inner Any type URL `type.googleapis.com/test.v1.TestMessage`.
+    - That value carries the payload of all three Any shapes: `test_any` (singular `any_field`), `test_any_repeated` (repeated), `test_any_map` (map).
+  </behavior>
+  <action>
+Add ONE new top-level test function to `inserter/inserter_test.go`, e.g.
+`TestProtoconfInserter_InsertConfig_AnyResolution`, following the file's existing fixture style:
+`dummykv.New(context.Background(), []string{}, &dummykv.Config{})` for the store,
+`testdata.SmallTestDir()` for the root, `NewProtoconfInserter(dir, kvStore)`, then
+`InsertConfigFile("field_type_any_test.materialized_JSON")` asserted with `require.NoError`, then
+`kvStore.Get(ctx, "field_type_any_test/config.json", &store.ReadOptions{})` and
+`assert.Contains` over the four substrings listed in the behavior block.
+
+Every import this needs (`context`, `testing`, `store`, `dummykv`, `testdata`, `assert`,
+`require`) is already present in the file — add no new imports and no new fixture files.
+
+Use a dedicated function rather than a row in `TestProtoconfInserter_InsertConfig`'s table on
+purpose: that table asserts with `strings.HasPrefix` against `"{"`, which cannot distinguish a
+resolved Any from any other JSON, and protojson deliberately randomizes its indentation
+whitespace, so a longer literal prefix would be flaky. Substring assertions are whitespace-proof.
+Leave the existing table and its two rows untouched.
+
+Prove the test is a real regression test before finishing: `git stash push inserter/inserter.go`,
+run `go test ./inserter/... -count=1 -run AnyResolution` and confirm it FAILS with the resolver
+error, then `git stash pop` and confirm it passes. Record both outcomes in the SUMMARY.
+  </action>
+  <verify>
+    <automated>go test ./inserter/... -count=1 && go build ./...</automated>
+  </verify>
+  <done>`go test ./inserter/... -count=1` passes with the fix and the new test fails without it (red/green both observed and recorded); no new imports, no new fixture files, existing test functions unmodified.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| inserter → KV store | Compiled config JSON written to Consul/etcd/ZooKeeper/ConfigMaps and later served to applications |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-eie-01 | Information Disclosure | `XXXinsertVersion` config.json write | low | accept | The resolver only widens type resolution to the project's own descriptors — the same set `parser.ReadConfig` already trusts on the read side, and the same binary `config.data` payload is already written unconditionally. No new data is exposed |
+| T-eie-02 | Denial of Service | `InsertConfigFile` | low | mitigate | This change removes a DoS-shaped failure: today one Any-bearing config aborts its entire insert. Regression test in Task 2 locks the behavior |
+| T-eie-SC | Tampering | package installs | n/a | accept | No package-manager install in this plan; no dependency added or changed |
+</threat_model>
+
+<verification>
+1. `go build ./...` — clean.
+2. `go test ./inserter/... -count=1` — all green, including the new Any-resolution test.
+3. `git diff --stat` — exactly two files touched (`inserter/inserter.go`, `inserter/inserter_test.go`); the production diff is one line; no `.pb.go` file appears.
+4. Red-check recorded: the new test fails on stashed-fix with `unable to resolve "type.googleapis.com/test.v1.TestMessage"`.
+</verification>
+
+<success_criteria>
+- Configs containing `google.protobuf.Any` of user-defined types insert successfully.
+- The written `config.json` contains the resolved Any payload for singular, repeated, and map fields.
+- The two sibling marshals in `inserter.go` (rollout, metadata) are unchanged.
+- No proto regeneration, no dependency change, nothing else from PR #496.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260902-eie-fix-any-resolution-in-inserter-json-mars/260902-eie-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260902-eie-fix-any-resolution-in-inserter-json-mars/260902-eie-SUMMARY.md
+++ b/.planning/quick/260902-eie-fix-any-resolution-in-inserter-json-mars/260902-eie-SUMMARY.md
@@ -1,0 +1,126 @@
+---
+phase: quick-260902-eie
+plan: 01
+subsystem: infra
+tags: [protobuf, protojson, dynamicpb, kvstore, inserter]
+
+# Dependency graph
+requires: []
+provides:
+  - "Any-typed materialized configs (any.new() output) now insert successfully into the KV store"
+  - "Regression test locking in Any resolution on the inserter's config.json write path"
+affects: [inserter, compiler-any-fields]
+
+# Actuals (#2632)
+actuals:
+  tokens: 542
+  tasks: 2
+  commits: 2
+
+tech-stack:
+  added: []
+  patterns: ["config.json write path now shares the same LocalResolver as the read path (parser.ReadConfig), closing the last resolver gap identified in the repo-wide audit"]
+
+key-files:
+  created: []
+  modified:
+    - inserter/inserter.go
+    - inserter/inserter_test.go
+
+key-decisions:
+  - "Backported only the Any-resolution one-line fix from upstream PR #496 -- left the two sibling protojson.MarshalOptions marshals (rollout, metadata) untouched since they marshal generated protoconf-owned types with no reachable Any field"
+  - "Wrote the regression test as a dedicated top-level function rather than a row in the existing table-driven test, since the table's strings.HasPrefix(\"{\") assertion can't distinguish a resolved Any from any other JSON and protojson randomizes indentation whitespace"
+
+requirements-completed: [QUICK-260902-EIE]
+
+coverage:
+  - id: D1
+    description: "Inserting a materialized config with populated singular/repeated/map google.protobuf.Any fields of a user-defined (LocalResolver-only) type succeeds and writes the resolved payload to config.json"
+    requirement: QUICK-260902-EIE
+    verification:
+      - kind: unit
+        ref: "inserter/inserter_test.go#TestProtoconfInserter_InsertConfig_AnyResolution"
+        status: pass
+    human_judgment: false
+
+duration: 12min
+completed: 2026-09-02
+status: complete
+---
+
+# Quick Task 260902-eie: Fix Any Resolution in Inserter config.json Marshal Summary
+
+**One-line fix: added `Resolver: i.parser.LocalResolver` to the config.json `protojson.MarshalOptions` in `XXXinsertVersion`, so materialized configs containing `google.protobuf.Any` of user-defined types (built via the `any.new()` Starlark builtin) insert successfully instead of aborting.**
+
+## Performance
+
+- **Duration:** 12 min
+- **Started:** 2026-09-02T03:23:00Z (approx)
+- **Completed:** 2026-09-02T03:35:31Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Fixed the missing `Resolver` on `(*ProtoconfInserter).XXXinsertVersion`'s config.json `protojson.Marshal`, matching the resolver already used on the read side (`parser.ReadConfig`) and the compiler's write side (`compiler/lib/compiler.go`)
+- Added `TestProtoconfInserter_InsertConfig_AnyResolution`, a dedicated regression test that inserts the existing `field_type_any_test.materialized_JSON` fixture and asserts the written `config.json` contains the resolved Any payload for all three shapes (singular, repeated, map)
+- Confirmed the test is a genuine regression test: manually reverted the fix, ran `go test ./inserter/... -run AnyResolution`, observed the exact `unable to resolve "type.googleapis.com/test.v1.TestMessage": not found` failure from the bug report, then restored the fix and confirmed the test passes
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Pass LocalResolver to the config.json protojson.Marshal** - `f65bdd7` (fix)
+2. **Task 2: Regression test proving Any values survive the config.json write** - `841ca1b` (test)
+
+**Plan metadata:** committed separately by the orchestrator (docs commit not made by this executor per constraints)
+
+## Files Created/Modified
+- `inserter/inserter.go` - Added `Resolver: i.parser.LocalResolver` to the config.json marshal's `protojson.MarshalOptions` (one line changed)
+- `inserter/inserter_test.go` - Added `TestProtoconfInserter_InsertConfig_AnyResolution`
+
+## Decisions Made
+- Did not touch the two sibling `protojson.MarshalOptions` marshals in the same file (rollout config at line ~308, metadata at line ~390) -- both marshal generated protoconf-owned Go types registered in `protoregistry.GlobalTypes` with no field path that can reach a `google.protobuf.Any`, per the plan's repo-wide sibling-call-site audit
+- Kept the regression test as a standalone top-level function instead of extending the existing table-driven `TestProtoconfInserter_InsertConfig`, to avoid a flaky/imprecise `strings.HasPrefix` assertion
+
+## Deviations from Plan
+
+None - plan executed exactly as written. No new imports, no new fixture files, existing test functions unmodified.
+
+## Issues Encountered
+
+None. The existing `field_type_any_test.materialized_JSON` fixture reproduced the bug exactly as documented in the plan's `<prior_investigation>` section, and the fix + test worked on the first attempt.
+
+## Red/Green Verification (Task 2)
+
+- **RED (fix manually reverted):** `go test ./inserter/... -count=1 -run AnyResolution -v` -> `FAIL`, error: `proto: google.protobuf.Any: unable to resolve "type.googleapis.com/test.v1.TestMessage": not found`
+- **GREEN (fix restored):** `go test ./inserter/... -count=1 -run AnyResolution -v` -> `PASS`
+
+## Final Verification
+
+```
+$ go build ./...
+(clean, no output)
+
+$ go test ./inserter/... -count=1
+ok  	github.com/protoconf/protoconf/inserter	17.086s
+?   	github.com/protoconf/protoconf/inserter/config/v1	[no test files]
+
+$ git diff --stat a659cd34f3cec45086f1f94b1bd9d074cee04d55 HEAD -- inserter/inserter.go inserter/inserter_test.go
+ inserter/inserter.go      |  2 +-
+ inserter/inserter_test.go | 24 ++++++++++++++++++++++++
+ 2 files changed, 25 insertions(+), 1 deletion(-)
+```
+
+Exactly two files touched; production diff is a single line change; no `.pb.go` file touched; no `go generate` run.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- The inserter's write path now matches the compiler and parser's Any-resolution behavior, closing the last gap identified in the upstream PR #496 audit.
+- No blockers. The remaining parts of PR #496 (etcd health check, GetConfig RPC, TLS, OTEL toggles) remain out of scope for this quick task, as intended.
+
+---
+*Phase: quick-260902-eie*
+*Completed: 2026-09-02*

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -376,7 +376,7 @@ func (i *ProtoconfInserter) XXXinsertVersion(configName string, version string, 
 		return err
 	}
 
-	data, err = protojson.MarshalOptions{Multiline: true}.Marshal(new)
+	data, err = protojson.MarshalOptions{Multiline: true, Resolver: i.parser.LocalResolver}.Marshal(new)
 	if err != nil {
 		return errors.Join(err, fmt.Errorf("error marshaling ProtoconfValue to json, value=%v", protoconfValue))
 	}

--- a/inserter/inserter_test.go
+++ b/inserter/inserter_test.go
@@ -70,6 +70,30 @@ func TestProtoconfInserter_InsertConfig(t *testing.T) {
 	}
 }
 
+// TestProtoconfInserter_InsertConfig_AnyResolution is a dedicated regression test (not a row in
+// TestProtoconfInserter_InsertConfig's table) for XXXinsertVersion's config.json marshal
+// resolving google.protobuf.Any values whose type only exists in the parser's LocalResolver.
+// The existing table asserts with strings.HasPrefix against "{", which cannot distinguish a
+// resolved Any from any other JSON, and protojson deliberately randomizes indentation
+// whitespace, so a longer literal prefix would be flaky; substring assertions are
+// whitespace-proof.
+func TestProtoconfInserter_InsertConfig_AnyResolution(t *testing.T) {
+	kvStore, _ := dummykv.New(context.Background(), []string{}, &dummykv.Config{})
+	testDir := testdata.SmallTestDir()
+	i := NewProtoconfInserter(testDir, kvStore)
+
+	err := i.InsertConfigFile("field_type_any_test.materialized_JSON")
+	require.NoError(t, err)
+
+	v, err := kvStore.Get(context.Background(), "field_type_any_test/config.json", &store.ReadOptions{})
+	require.NoError(t, err)
+	got := string(v.Value)
+	assert.Contains(t, got, "type.googleapis.com/test.v1.TestMessage")
+	assert.Contains(t, got, "test_any")
+	assert.Contains(t, got, "test_any_repeated")
+	assert.Contains(t, got, "test_any_map")
+}
+
 func Test_cliCommand_Run(t *testing.T) {
 	testDir := testdata.SmallTestDir()
 	type args struct {


### PR DESCRIPTION
Extracted from #496 (`* fix any.new() usage to let users embed messages as google.protobuf.Any`).

## Problem

`ProtoconfInserter.XXXinsertVersion` writes the human-readable `config.json` with:

```go
data, err = protojson.MarshalOptions{Multiline: true}.Marshal(new)
```

With no `Resolver`, protojson falls back to `protoregistry.GlobalTypes`. But `new` is a `dynamicpb.Message` built from a descriptor resolved out of `i.parser.LocalResolver` — the registry holding the *project's own* protos, which have no generated `.pb.go` and are therefore absent from `GlobalTypes`.

So any config whose value embeds a `google.protobuf.Any` — exactly what the `any.new()` Starlark builtin produces — fails the insert outright:

```
unable to resolve "type.googleapis.com/test.v1.TestMessage": not found
```

The read side (`parser.ReadConfig`) already passes `Resolver: p.LocalResolver`. This is the write side catching up.

## Fix

One line — pass the same resolver.

## Sibling audit

Every other `protojson` call site that can carry a user-defined message was checked; this was the only gap:

| Call site | Verdict |
|---|---|
| `inserter.go:379` (config.json) | **fixed** — marshals the user's dynamic value |
| `inserter.go:308` (rollout) | left alone — `ConfigRollout`, generated type, no reachable Any |
| `inserter.go:390` (metadata) | left alone — `Metadata`, generated type, no reachable Any |
| `server/server.go:416`, `compiler/lib/compiler.go:294`, `parser.ReadConfig` | already pass a resolver |

## Test

`TestProtoconfInserter_InsertConfig_AnyResolution` uses the existing `field_type_any_test.materialized_JSON` fixture, which already carries singular, repeated, and map Any fields of type `test.v1.TestMessage` — a type that exists *only* in `LocalResolver`. No new fixture surface.

Confirmed red-before / green-after: fails with the resolve error on `main`, passes with the fix.

It asserts with `assert.Contains` rather than a literal prefix because protojson deliberately randomizes indentation whitespace.

```
$ go build ./...
$ go test ./inserter/...
ok  	github.com/protoconf/protoconf/inserter	17.086s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msxscm8fhgmYuPcYQwFTjZ