### PR TITLE
fix(agent): probe a valid key for store availability so etcd-backed agents can start

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -156,6 +156,7 @@ None yet.
 | 260902-cov | Give codecov a 1% project threshold and mark patch informational, so codecov/project stops failing on rounding noise | 2026-09-02 | 3238abe | — |
 | 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
 | 260902-eie | Resolve google.protobuf.Any types when the inserter marshals config.json (backport of upstream PR #496) | 2026-09-02 | 841ca1b | [260902-eie-fix-any-resolution-in-inserter-json-mars](./quick/260902-eie-fix-any-resolution-in-inserter-json-mars/) |
+| 260902-erj | Fix agent startup against etcd — store health probe used "/", which etcd normalizes to an empty key and rejects (backport of upstream PR #496) | 2026-09-02 | db33bbd | [260902-erj-fix-etcd-agent-startup-invalid-store-hea](./quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/260902-erj-PLAN.md
+++ b/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/260902-erj-PLAN.md
@@ -1,0 +1,226 @@
+---
+phase: 260902-erj
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent/kv_agent_impl.go
+  - agent/kv_agent_rollout_impl.go
+  - agent/store_probe_test.go
+autonomous: true
+requirements: [QUICK-260902-erj]
+
+estimate:
+  tokens: 35000
+  raw_tokens: 23000
+  tasks: 2
+  confidence: low
+
+must_haves:
+  truths:
+    - "The agent starts successfully against an etcd store that is reachable but empty"
+    - "The agent still refuses to start when the KV store is unreachable (fail-fast preserved, NOT deleted)"
+    - "Both NewProtoconfKVAgent and NewProtoconfKVAgentRollout probe with the same valid key"
+    - "The probe key is non-empty after the backend strips its leading slash, for any value of config.Prefix including empty"
+    - "A key that is merely absent is treated as success — a fresh store legitimately holds nothing"
+  artifacts:
+    - "agent/kv_agent_impl.go — one unexported checkStoreAvailable helper, called by both constructors"
+    - "agent/store_probe_test.go — table test over both constructors using a local store.Store fake"
+  key_links:
+    - "path.Join(config.GetPrefix(), storeProbeKey) — the sentinel is always appended, so the result is never bare \"/\" and never normalizes to the empty string"
+    - "store.Exists maps store.ErrKeyNotFound to (false, nil); only a transport error yields a non-nil error, so `if err != nil` is already the correct absent-is-success predicate"
+---
+
+<objective>
+Fix agent startup against etcd at the root: the store-reachability probe in both agent
+constructors passes the key `"/"`, which `kvtools/etcdv3`'s `normalize` (a bare
+`strings.TrimPrefix(key, "/")`) reduces to the EMPTY STRING. etcd rejects an empty key with
+`rpctypes.ErrEmptyKey` ("etcdserver: key is not provided"). That is a transport-level error,
+not `store.ErrKeyNotFound`, so `Exists` propagates it and the constructor fails on a
+perfectly healthy store.
+
+Purpose: upstream PR #496 "fixed" this by commenting the whole check out, which trades a
+false startup failure for a real one — an unreachable store would then surface as a failure
+on every subscription instead of once at boot. We keep the fail-fast check and give it a
+valid key.
+
+Verified before writing this plan (do not re-derive):
+- `etcdv3@v1.0.3` `Exists` -> `Get`; `Get` returns `store.ErrKeyNotFound` only when
+  `result.Count == 0`, and `Exists` swallows exactly that into `(false, nil)`. Every other
+  error propagates. So **key-absent is already success** and the existing `if err != nil`
+  predicate is correct as written — only the key is wrong.
+- `agent/filekv` and `agent/configmaps` hardcode `Exists` to `return true, nil`;
+  `kvtools/consul` maps its empty-key miss to `ErrKeyNotFound`. etcd is the only backend
+  that trips, which is why this went unnoticed.
+- `agent/otelkv` `Exists` is a pass-through wrapper, so the fix applies through it.
+- `AgentConfig.GetPrefix()` is the generated nil-safe getter.
+- Callers of the two constructors: `agent/agent.go:116,118`, `devserver/command.go:53`,
+  `test/e2e_test.go:275,296`, plus `agent/kv_agent_impl_test.go`. None need changes —
+  the constructor signatures are unchanged.
+
+Output: one shared `checkStoreAvailable` helper wired into both constructors, and a
+regression test that provably fails against the unfixed code. Two commits.
+</objective>
+
+<execution_context>
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/workflows/execute-plan.md
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+@agent/kv_agent_impl.go
+@agent/kv_agent_rollout_impl.go
+@agent/kv_agent_impl_test.go
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Failing regression test for the store-availability probe (RED)</name>
+  <files>agent/store_probe_test.go</files>
+  <behavior>
+    New file, `package agent`. Follow the style of `agent/kv_agent_impl_test.go`:
+    testify `require`/`assert`, table-driven subtests.
+
+    Define a local fake, NOT a change to `agent/dummykv` — `dummykv.Exists` hardcodes
+    `return true, nil`, so it cannot express either case, and making it real would require
+    also changing `dummykv.Get` (which returns a plain `fmt.Errorf`, not
+    `store.ErrKeyNotFound`) and would break every existing dummykv-backed test:
+
+      type probeStore struct {
+          store.Store   // embedded so only Exists needs a body; nothing else is called
+          gotKey string
+          exists bool
+          err    error
+      }
+      func (p *probeStore) Exists(_ context.Context, key string, _ *store.ReadOptions) (bool, error)
+
+    `Exists` records `key` into `gotKey` and returns the canned `exists`/`err`.
+
+    Table over BOTH constructors so neither can regress independently. Give the table a
+    `newAgent func(store.Store, *protoconf_agent_config.AgentConfig) error` column with two
+    rows — one adapting `NewProtoconfKVAgent`, one adapting `NewProtoconfKVAgentRollout` —
+    each discarding the concrete agent and returning only the error.
+
+    For each constructor, three assertions:
+    - Test 1 (THE regression assertion, the only one that goes red before Task 2):
+      probe key validity. With `exists:false, err:nil`, run the constructor for
+      `Prefix: ""` and for `Prefix: "some/prefix"`, and in both cases assert
+      `strings.TrimPrefix(store.gotKey, "/")` is NOT the empty string. Assert the
+      invariant, not a hardcoded sentinel string, so renaming the sentinel later does not
+      break the test. This is exactly etcd's `normalize`, reproduced in the assertion.
+    - Test 2 (absent key succeeds): `exists:false, err:nil` -> constructor returns nil
+      error. A fresh, reachable, empty store must not block startup.
+    - Test 3 (transport error fails): `err: errors.New("etcdserver: key is not provided")`
+      -> constructor returns a non-nil error whose message contains
+      "store is not available". Fail-fast is preserved.
+
+    Expected RED behavior, so the executor is not surprised: the file COMPILES against the
+    current unfixed constructors (their signatures are unchanged), and Tests 2 and 3 PASS
+    before the fix. Only Test 1 fails, because the current probe key normalizes to "".
+    A compile error here means the fake or the adapters are wrong, not that RED was reached.
+  </behavior>
+  <action>
+    Create `agent/store_probe_test.go` implementing the behavior above. Do not touch
+    `agent/dummykv`, do not touch either constructor in this task, and do not add any
+    dependency — `store`, `errors`, `strings`, `context`, `testing` and testify are all
+    already in use in this package.
+  </action>
+  <verify>
+    <automated>cd /Users/smintz/go/src/github.com/protoconf/protoconf && go vet ./agent/ && if go test ./agent/ -run TestStoreAvailabilityProbe -count=1 >/dev/null 2>&1; then echo "UNEXPECTED PASS - test does not detect the bug"; exit 1; else echo "RED confirmed"; fi</automated>
+  </verify>
+  <done>`agent/store_probe_test.go` compiles and vets clean; `go test ./agent/ -run TestStoreAvailabilityProbe` FAILS on the probe-key assertion (not on a compile error) for both constructors.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Extract one shared checkStoreAvailable helper and wire both constructors (GREEN)</name>
+  <files>agent/kv_agent_impl.go, agent/kv_agent_rollout_impl.go</files>
+  <behavior>
+    After this task `go test ./agent/ -run TestStoreAvailabilityProbe` passes all three
+    assertions for both constructors, and the rest of `./agent/...` is unaffected.
+  </behavior>
+  <action>
+    In `agent/kv_agent_impl.go` add a package-level sentinel const and one unexported
+    helper. Put both in this file rather than a new file — it already imports `context`,
+    `errors`, `path`, `store` and `protoconf_agent_config`, so the change adds zero imports
+    anywhere. Keep it to a const plus a function: no interface, no options struct, no new
+    package.
+
+    The const is a dot-prefixed sentinel name such as `.protoconf-agent-healthcheck`,
+    chosen so it will not collide with a real config path. The helper takes a
+    `context.Context`, a `store.Store` and the `*protoconf_agent_config.AgentConfig`, builds
+    the probe key with `path.Join(config.GetPrefix(), storeProbeKey)`, calls
+    `Exists(ctx, key, nil)`, and returns the existing `errors.Join(errors.New("store is not
+    available"), err)` on a non-nil error, nil otherwise. Use the generated `GetPrefix()`
+    getter, not direct field access, so a nil config cannot panic. `path.Join` collapses an
+    empty prefix correctly, and because the sentinel is always appended the result is never
+    bare "/" and therefore never normalizes to the empty string on etcd.
+
+    Document WHY in a comment on the helper: the key must stay non-empty after the
+    backend's leading-slash normalization, because etcd rejects an empty key with a
+    transport error that `Exists` does not swallow; and an absent key is deliberately
+    success, because `Exists` maps `store.ErrKeyNotFound` to `(false, nil)` so only a
+    transport error reaches the caller.
+
+    Then replace the two byte-identical probe blocks — `agent/kv_agent_impl.go` line 28 and
+    `agent/kv_agent_rollout_impl.go` line 54 — with a call to the helper, passing
+    `context.Background()` to preserve current behavior. Do NOT delete or comment out the
+    check, and do not change either constructor's signature. Confirm `errors` and `context`
+    are still used elsewhere in the rollout file (they are, at lines 236/304 and throughout)
+    so no import goes stale.
+  </action>
+  <verify>
+    <automated>cd /Users/smintz/go/src/github.com/protoconf/protoconf && gofmt -l agent/ | (! grep .) && go build ./... && go test ./agent/... -count=1 && grep -c checkStoreAvailable agent/kv_agent_impl.go agent/kv_agent_rollout_impl.go && (! grep -rn 'Exists(context.Background(), "/"' agent/)</automated>
+  </verify>
+  <done>`go build ./...` and `go test ./agent/...` both pass; `checkStoreAvailable` is referenced in both constructor files (count >= 2 in kv_agent_impl.go, >= 1 in kv_agent_rollout_impl.go); the old empty-normalizing probe call appears nowhere under `agent/`; gofmt reports no diffs.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| agent -> KV store (etcd/consul/zookeeper/configmaps/file) | Network call to an external datastore at process startup |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-260902erj-01 | Denial of Service | `checkStoreAvailable` in `agent/kv_agent_impl.go` | medium | mitigate | Retain the fail-fast probe rather than deleting it (the PR #496 approach). An unreachable store must fail once at boot, not on every client subscription. Task 1 Test 3 asserts a transport error still aborts the constructor. |
+| T-260902erj-02 | Information Disclosure | probe sentinel key | low | accept | The probe issues a read-only `Exists` against a dot-prefixed sentinel under the operator's own configured prefix. It never writes, and reveals nothing a client subscription would not. |
+
+No package-manager installs and no dependency changes in this plan, so the supply-chain
+threat row does not apply. No `.pb.go` file is touched and `go generate` is not run.
+</threat_model>
+
+<verification>
+1. `go build ./...` — whole module still builds; no caller of either constructor broke.
+2. `go test ./agent/... -count=1` — the new probe test passes and no existing
+   dummykv/filekv-backed agent test regressed.
+3. `grep -rn 'Exists(context.Background(), "/"' agent/` returns nothing — the
+   empty-normalizing probe is gone from both files, at the root, not patched in one.
+4. Sanity: `go test ./test/... -count=1 -run TestE2E` still passes (e2e constructs both
+   agents against filekv/dummykv, whose `Exists` hardcodes `true, nil`, so it should be
+   unaffected — if it fails, the helper signature or nil-config handling is wrong).
+</verification>
+
+<success_criteria>
+- One shared `checkStoreAvailable` helper exists; neither constructor carries its own copy
+  of the probe, and the fix is not duplicated.
+- The probe key is non-empty after leading-slash normalization for both an empty and a
+  non-empty `config.Prefix`, asserted by test for both constructors.
+- Key-absent returns success; a transport error still aborts startup with
+  "store is not available".
+- No behavior change for consul, zookeeper, filekv, configmaps, or the otelkv wrapper.
+- Scope held: no Any resolver, no GetConfig RPC, no TLS, no OTEL toggles from PR #496.
+- Two atomic commits: `test(260902-erj): ...` then `fix(260902-erj): ...`.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/260902-erj-SUMMARY.md` when done
+</output>

--- a/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/260902-erj-SUMMARY.md
+++ b/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/260902-erj-SUMMARY.md
@@ -1,0 +1,178 @@
+---
+phase: 260902-erj
+plan: 01
+subsystem: infra
+tags: [etcd, grpc, kv-store, valkeyrie, agent-startup]
+
+requires: []
+provides:
+  - "checkStoreAvailable shared helper in agent/kv_agent_impl.go, wired into both agent constructors"
+  - "Regression test proving both constructors probe a non-empty key regardless of config.Prefix"
+affects: [agent, devserver]
+
+actuals:
+  tokens: 1314
+  tasks: 2
+  commits: 2
+
+tech-stack:
+  added: []
+  patterns:
+    - "Shared reachability probe helper (checkStoreAvailable) instead of duplicated inline checks in each constructor"
+
+key-files:
+  created:
+    - agent/store_probe_test.go
+  modified:
+    - agent/kv_agent_impl.go
+    - agent/kv_agent_rollout_impl.go
+
+key-decisions:
+  - "Kept the fail-fast reachability check rather than deleting it (as upstream PR #496 did) - an unreachable store must fail once at boot, not on every client subscription"
+  - "Used path.Join(config.GetPrefix(), storeProbeKey) with a dot-prefixed sentinel key so the joined probe key is never empty after the backend's leading-slash normalization, for any prefix value"
+  - "Used a local probeStore fake embedding store.Store in the regression test instead of extending agent/dummykv, since dummykv.Exists hardcodes true and dummykv.Get doesn't return store.ErrKeyNotFound"
+
+requirements-completed: [QUICK-260902-erj]
+
+coverage:
+  - id: D1
+    description: "Agent constructors probe a non-empty key after prefix normalization, so a reachable-but-empty etcd store no longer fails startup"
+    requirement: "QUICK-260902-erj"
+    verification:
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgent/probe_key_is_non-empty_after_leading-slash_normalization"
+        status: pass
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgentRollout/probe_key_is_non-empty_after_leading-slash_normalization"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Fail-fast behavior preserved: a transport error from the store still aborts agent construction with 'store is not available'"
+    requirement: "QUICK-260902-erj"
+    verification:
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgent/transport_error_fails"
+        status: pass
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgentRollout/transport_error_fails"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "A key that is merely absent (fresh, empty store) is treated as success, not a startup failure"
+    requirement: "QUICK-260902-erj"
+    verification:
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgent/absent_key_succeeds"
+        status: pass
+      - kind: unit
+        ref: "agent/store_probe_test.go#TestStoreAvailabilityProbe/NewProtoconfKVAgentRollout/absent_key_succeeds"
+        status: pass
+    human_judgment: false
+
+duration: 25min
+completed: 2026-09-02
+status: complete
+---
+
+# Quick Task 260902-erj: Fix etcd agent startup invalid store health-check key
+
+**Extracted a shared `checkStoreAvailable` helper that probes `path.Join(config.GetPrefix(), storeProbeKey)` instead of the bare `"/"`, fixing false startup failures against a healthy, empty etcd store while keeping the fail-fast check PR #496 deleted.**
+
+## Performance
+
+- **Duration:** ~25 min
+- **Started:** 2026-09-02T10:41:00Z (plan authored) / execution ~10:44-11:09
+- **Completed:** 2026-09-02
+- **Tasks:** 2
+- **Files modified:** 3 (2 modified, 1 created)
+
+## Accomplishments
+- Root-caused and fixed the etcd startup failure: `Exists(ctx, "/", nil)` normalizes to the empty string under `kvtools/etcdv3`, which etcd rejects with a transport-level `ErrEmptyKey` even against a perfectly reachable store
+- Extracted one shared `checkStoreAvailable(ctx, store, config)` helper used by both `NewProtoconfKVAgent` and `NewProtoconfKVAgentRollout`, eliminating the duplicated byte-identical probe blocks
+- Added a table-driven regression test (`TestStoreAvailabilityProbe`) covering both constructors: probe-key-non-empty invariant, absent-key-succeeds, and transport-error-still-fails
+- Preserved fail-fast behavior instead of deleting the check (the approach upstream PR #496 took, which trades a false startup failure for a real one)
+
+## Task Commits
+
+Each task was committed atomically (TDD RED/GREEN cycle):
+
+1. **Task 1: Failing regression test for the store-availability probe (RED)** - `9aefb2d` (test)
+2. **Task 2: Extract shared checkStoreAvailable helper and wire both constructors (GREEN)** - `db33bbd` (fix)
+
+**Plan metadata:** commit deferred to orchestrator per constraints (this SUMMARY, STATE.md, PLAN.md not committed by executor)
+
+## Files Created/Modified
+- `agent/store_probe_test.go` - New regression test; local `probeStore` fake (embeds `store.Store`) records the probed key and returns canned exists/err values; table over both constructors
+- `agent/kv_agent_impl.go` - Added `storeProbeKey` const and `checkStoreAvailable` helper; `NewProtoconfKVAgent` now calls it
+- `agent/kv_agent_rollout_impl.go` - `NewProtoconfKVAgentRollout` now calls the shared helper instead of its own inline probe
+
+## Decisions Made
+- Kept the reachability check (threat model T-260902erj-01 disposition "mitigate") rather than deleting it - an unreachable store must fail once at boot, not surface as a failure on every client subscription
+- Sentinel key `.protoconf-agent-healthcheck` chosen dot-prefixed so it won't collide with real config paths; documented via GoDoc comment on `checkStoreAvailable` explaining both the non-empty-key requirement and the absent-key-is-success behavior
+- Test fake is a new local `probeStore` type rather than extending `agent/dummykv`, since `dummykv.Exists` hardcodes `(true, nil)` and `dummykv.Get` returns a plain `fmt.Errorf` rather than `store.ErrKeyNotFound` - changing it would have broken every existing dummykv-backed test
+
+## Deviations from Plan
+
+None - plan executed exactly as written. Two pre-existing, out-of-scope environmental issues were discovered and documented (not fixed, per SCOPE BOUNDARY) rather than deviations from the plan itself:
+
+### Deferred (out-of-scope, not auto-fixed)
+
+**1. Pre-existing `go vet ./agent/` findings unrelated to this task**
+- `agent/agent_test.go:27` - discarded `context.WithTimeoutCause` cancel func (introduced 2024-03-17, commit f7ba446)
+- `agent/legacy.go:97` - unreachable code (introduced 2024-05-27, commit fb46573)
+- Neither file is in this task's `files_modified` list; `go build ./...` and `go test ./agent/...` both pass regardless. Logged to `deferred-items.md`, left unfixed per scope discipline.
+
+**2. `Test_cliCommand_Run/run_consul_server` hangs in this specific dev sandbox (environmental)**
+- This machine has a real local Consul agent listening on `127.0.0.1:8500` (confirmed via `lsof -i :8500`, unrelated to this repo). The test expects the agent to fail to start (`want: 1`) assuming no Consul is reachable, but here it connects successfully - identical behavior before and after this fix, since a live server responds regardless of the exact probe key. With the store check passing, `agent.RunAgent` (called with `context.Background()`, no timeout) starts serving and blocks forever inside the test.
+- Confirmed via `go test ./agent/... -count=1 -timeout 30s` (times out inside `run_consul_server`'s gRPC/OTel goroutines) versus `go test ./agent/... -count=1 -skip Test_cliCommand_Run` (all pass, including the new `TestStoreAvailabilityProbe`). Not caused by this task's changes; logged to `deferred-items.md`.
+
+---
+
+**Total deviations:** 0
+**Impact on plan:** None - both deferred items are pre-existing and environment-specific, unrelated to the store-probe fix.
+
+## Issues Encountered
+- The plan's sanity-check command `go test ./test/... -count=1 -run TestE2E` doesn't match an actual test name (the e2e test function is named `Test`, not `TestE2E`). Ran `go test ./test/... -count=1` instead, which covers the same intent (agents constructed against filekv/dummykv) - all 4 tests pass.
+
+## Verification Results
+
+```
+$ go build ./...
+(exit 0, no output)
+
+$ go test ./agent/... -count=1 -skip Test_cliCommand_Run
+ok  	github.com/protoconf/protoconf/agent	22.5s
+ok  	github.com/protoconf/protoconf/agent/configmaps	1.2s
+ok  	github.com/protoconf/protoconf/agent/dummykv	7.6s
+ok  	github.com/protoconf/protoconf/agent/filekv	7.3s
+ok  	github.com/protoconf/protoconf/agent/otelkv	1.7s
+(all PASS, including TestStoreAvailabilityProbe for both constructors)
+
+$ grep -rn 'Exists(context.Background(), "/"' agent/
+(no output - old empty-normalizing probe removed from both files)
+
+$ go test ./test/... -count=1
+ok  	github.com/protoconf/protoconf/test	4.9s
+(TestMutationWithScripts, TestTLSMutation, TestAuthFlow, Test all PASS)
+```
+
+`go test ./agent/...` without `-skip` hangs specifically on `Test_cliCommand_Run/run_consul_server` due to the environmental Consul collision described above - not a regression from this change (see Deviations).
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Agent starts correctly against a reachable-but-empty etcd store; no further action needed for this fix
+- The two deferred items (pre-existing `go vet` findings, environment-specific Consul test hang) remain available in `deferred-items.md` for anyone auditing `agent/command_test.go` or `agent/legacy.go` separately - out of scope for this task
+
+---
+*Phase: 260902-erj*
+*Completed: 2026-09-02*
+
+## Self-Check: PASSED
+- FOUND: agent/store_probe_test.go
+- FOUND: agent/kv_agent_impl.go (modified, checkStoreAvailable present)
+- FOUND: agent/kv_agent_rollout_impl.go (modified, checkStoreAvailable wired)
+- FOUND commit: 9aefb2d (test)
+- FOUND commit: db33bbd (fix)

--- a/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/deferred-items.md
+++ b/.planning/quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/deferred-items.md
@@ -1,0 +1,32 @@
+# Deferred Items — 260902-erj
+
+Out-of-scope pre-existing issues discovered during execution (SCOPE BOUNDARY rule: only auto-fix issues directly caused by this task's changes).
+
+## `go vet ./agent/` failures (pre-existing, unrelated to this task)
+
+1. `agent/agent_test.go:27` — `context.WithTimeoutCause` cancel func discarded (context leak). Introduced in commit f7ba446 (2024-03-17).
+2. `agent/legacy.go:97` — unreachable code. Introduced in commit fb46573 (2024-05-27).
+
+Neither file is in this task's `files_modified` list. `go build ./...` and `go test ./agent/...` both pass; only whole-package `go vet` trips on these two pre-existing findings. Left unfixed per scope discipline.
+
+## `Test_cliCommand_Run/run_consul_server` hangs in this dev sandbox (pre-existing, environmental)
+
+`go test ./agent/...` (top-level `agent` package, unbounded) times out because
+`Test_cliCommand_Run/run_consul_server` in `agent/command_test.go` (want: 1,
+i.e. expects the agent to fail to start) actually succeeds at connecting: this
+specific machine has a real local Consul agent listening on `127.0.0.1:8500`
+(confirmed via `lsof -i :8500`, unrelated to this repo). `checkStoreAvailable`
+reaches that real server and returns nil either way -- this is identical
+before and after the fix, since the pre-fix code's probe key `"/"` also
+normalizes to a real, reachable request against a live Consul. With the store
+check passing, `agent.RunAgent` (called with `context.Background()`, no
+timeout) starts serving and blocks forever inside the test, since nothing
+ever cancels it.
+
+This is a pre-existing test/environment collision, not caused by this task's
+changes -- confirmed with `go test ./agent/... -count=1 -timeout 30s`, which
+times out inside `run_consul_server`'s gRPC/OTel goroutines, while
+`go test ./agent/... -count=1 -skip Test_cliCommand_Run` and
+`go test ./agent/configmaps/... ./agent/dummykv/... ./agent/filekv/... ./agent/otelkv/...`
+all pass cleanly, including the new `TestStoreAvailabilityProbe`. Not fixed
+per scope discipline (`agent/command_test.go` is not in `files_modified`).

--- a/agent/kv_agent_impl.go
+++ b/agent/kv_agent_impl.go
@@ -24,10 +24,34 @@ type ProtoconfKVAgent struct {
 
 var tracer = otel.Tracer("protoconf-agent")
 
-func NewProtoconfKVAgent(store store.Store, config *protoconf_agent_config.AgentConfig) (*ProtoconfKVAgent, error) {
-	_, err := store.Exists(context.Background(), "/", nil)
+// storeProbeKey is the sentinel key used by checkStoreAvailable to verify the
+// store is reachable at startup. It is dot-prefixed so it will not collide
+// with a real config path.
+const storeProbeKey = ".protoconf-agent-healthcheck"
+
+// checkStoreAvailable does a read-only reachability check against the store
+// at construction time, so an unreachable store fails fast once at boot
+// rather than on every client subscription.
+//
+// The probe key must stay non-empty after the backend's leading-slash
+// normalization: etcd rejects an empty key with a transport error that
+// Exists does not swallow, so path.Join(config.GetPrefix(), storeProbeKey)
+// is used instead of a bare "/" to guarantee the joined key is never empty,
+// for any value of config.Prefix including empty. An absent key is
+// deliberately treated as success — Exists maps store.ErrKeyNotFound to
+// (false, nil), so only a transport error reaches the caller here.
+func checkStoreAvailable(ctx context.Context, s store.Store, config *protoconf_agent_config.AgentConfig) error {
+	key := path.Join(config.GetPrefix(), storeProbeKey)
+	_, err := s.Exists(ctx, key, nil)
 	if err != nil {
-		return nil, errors.Join(errors.New("store is not available"), err)
+		return errors.Join(errors.New("store is not available"), err)
+	}
+	return nil
+}
+
+func NewProtoconfKVAgent(store store.Store, config *protoconf_agent_config.AgentConfig) (*ProtoconfKVAgent, error) {
+	if err := checkStoreAvailable(context.Background(), store, config); err != nil {
+		return nil, err
 	}
 	logger := slog.Default()
 	return &ProtoconfKVAgent{store: store, config: config, Logger: logger}, nil

--- a/agent/kv_agent_rollout_impl.go
+++ b/agent/kv_agent_rollout_impl.go
@@ -51,9 +51,8 @@ var (
 )
 
 func NewProtoconfKVAgentRollout(store store.Store, config *protoconf_agent_config.AgentConfig) (*ProtoconfKVAgentRollout, error) {
-	_, err := store.Exists(context.Background(), "/", nil)
-	if err != nil {
-		return nil, errors.Join(errors.New("store is not available"), err)
+	if err := checkStoreAvailable(context.Background(), store, config); err != nil {
+		return nil, err
 	}
 	return newProtoconfKVAgentRollout(store, config), nil
 }

--- a/agent/store_probe_test.go
+++ b/agent/store_probe_test.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kvtools/valkeyrie/store"
+	protoconf_agent_config "github.com/protoconf/protoconf/agent/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// probeStore is a local store.Store fake used only to observe the key passed
+// to Exists by the agent constructors, and to control what Exists returns.
+// It embeds store.Store so only Exists needs a body; nothing else is called
+// during construction.
+type probeStore struct {
+	store.Store
+	gotKey string
+	exists bool
+	err    error
+}
+
+func (p *probeStore) Exists(_ context.Context, key string, _ *store.ReadOptions) (bool, error) {
+	p.gotKey = key
+	return p.exists, p.err
+}
+
+func TestStoreAvailabilityProbe(t *testing.T) {
+	newAgentConstructors := []struct {
+		name     string
+		newAgent func(store.Store, *protoconf_agent_config.AgentConfig) error
+	}{
+		{
+			name: "NewProtoconfKVAgent",
+			newAgent: func(s store.Store, cfg *protoconf_agent_config.AgentConfig) error {
+				_, err := NewProtoconfKVAgent(s, cfg)
+				return err
+			},
+		},
+		{
+			name: "NewProtoconfKVAgentRollout",
+			newAgent: func(s store.Store, cfg *protoconf_agent_config.AgentConfig) error {
+				_, err := NewProtoconfKVAgentRollout(s, cfg)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range newAgentConstructors {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("probe key is non-empty after leading-slash normalization", func(t *testing.T) {
+				for _, prefix := range []string{"", "some/prefix"} {
+					ps := &probeStore{exists: false, err: nil}
+					err := tc.newAgent(ps, &protoconf_agent_config.AgentConfig{Prefix: prefix})
+					require.NoError(t, err)
+					normalized := strings.TrimPrefix(ps.gotKey, "/")
+					assert.NotEmpty(t, normalized, "probe key %q normalizes to empty for prefix %q", ps.gotKey, prefix)
+				}
+			})
+
+			t.Run("absent key succeeds", func(t *testing.T) {
+				ps := &probeStore{exists: false, err: nil}
+				err := tc.newAgent(ps, &protoconf_agent_config.AgentConfig{})
+				assert.NoError(t, err)
+			})
+
+			t.Run("transport error fails", func(t *testing.T) {
+				ps := &probeStore{err: errors.New("etcdserver: key is not provided")}
+				err := tc.newAgent(ps, &protoconf_agent_config.AgentConfig{})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "store is not available")
+			})
+		})
+	}
+}


### PR DESCRIPTION
Extracted from #496 (`* allow etcd to work by disabling the exist check`) — but fixed at the root rather than by deleting the check.

## Problem

The agent refuses to start when backed by etcd. Both constructors ran the same probe:

```go
_, err := store.Exists(context.Background(), "/", nil)
```

Traced through the dependency:

1. `kvtools/etcdv3` `Store.Exists` → `Store.Get` → `s.client.Get(ctx, normalize(key))`
2. `normalize` is `strings.TrimPrefix(key, "/")` — so the probe key `"/"` becomes the **empty string**
3. etcd rejects an empty key with `rpctypes.ErrEmptyKey` (`etcdserver: key is not provided`)

That is a transport-level error, **not** `store.ErrKeyNotFound`, so `Exists` propagates it and the constructor fails.

Why nobody else noticed: `kvtools/consul` has an identical `normalize`, but Consul returns a plain miss for an empty key, which maps to `ErrKeyNotFound`, which `Exists` swallows into `(false, nil)`. `agent/filekv` and `agent/configmaps` both hardcode `Exists` to `return true, nil`. etcd is the only backend that trips.

## Fix

#496 commented the check out entirely. That loses a real property — fail fast once at boot instead of surfacing an unreachable store on every client subscription — so instead the probe now uses a key that survives normalization:

```go
path.Join(config.GetPrefix(), ".protoconf-agent-healthcheck")
```

`path.Join` collapses correctly for an empty `Prefix`, and the dot prefix keeps it from colliding with a real config path. `Exists` on a valid-but-absent key still round-trips to the server, so it proves reachability exactly as well as `"/"` was meant to.

**Absent key stays a success.** A fresh store legitimately has nothing in it; only a transport error fails startup. `Exists` already maps `ErrKeyNotFound` to `(false, nil)`, so the existing `if err != nil` predicate was correct — only the key was wrong.

## Root cause, both callers

`NewProtoconfKVAgent` and `NewProtoconfKVAgentRollout` carried a byte-identical broken snippet. Both now route through one small `checkStoreAvailable` helper, so there is one place left to get this wrong.

## Test

`TestStoreAvailabilityProbe` runs both constructors against a local `store.Store` fake (embedded interface, only `Exists` implemented) and asserts:

- the probe key is non-empty **after** leading-slash normalization, for both empty and non-empty `Prefix` — this is the assertion that goes red on `main`
- an absent key succeeds
- a transport error fails with `store is not available`

`agent/dummykv` couldn't express this — its `Exists` hardcodes `true, nil`, and making it real would need `dummykv.Get` to return `store.ErrKeyNotFound` instead of a bare `fmt.Errorf`, breaking every existing dummykv-backed test. Out of scope for a probe fix.

## Verification

```
$ go build ./...
$ go test ./agent/... -count=1 -skip Test_cliCommand_Run
ok  github.com/protoconf/protoconf/agent            24.966s
ok  github.com/protoconf/protoconf/agent/configmaps  1.925s
ok  github.com/protoconf/protoconf/agent/dummykv     6.954s
ok  github.com/protoconf/protoconf/agent/filekv      6.831s
ok  github.com/protoconf/protoconf/agent/otelkv      2.407s
$ go test ./test/... -count=1   # all 4 e2e pass
```

`Test_cliCommand_Run/run_consul_server` is skipped locally only: this dev box has a real Consul listening on `127.0.0.1:8500`, and that test expects the agent to *fail* to start against an unreachable store — so `RunAgent` (called with `context.Background()`, no timeout) connects and blocks forever. Identical before and after this change; a live server responds regardless of the probe key. CI has no Consul, so it should run normally there — worth a look at the checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msxscm8fhgmYuPcYQwFTjZ