### PR TITLE
fix(filekv): guard closeWatchers with the lock, make it idempotent, sound receivers

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -157,6 +157,7 @@ None yet.
 | 3 | Give codecov a 1% threshold so codecov/project stops failing on rounding noise | 2026-09-01 | 3238abe | — |
 | 260902-eie | Resolve google.protobuf.Any types when the inserter marshals config.json (backport of upstream PR #496) | 2026-09-02 | 841ca1b | [260902-eie-fix-any-resolution-in-inserter-json-mars](./quick/260902-eie-fix-any-resolution-in-inserter-json-mars/) |
 | 260902-erj | Fix agent startup against etcd — store health probe used "/", which etcd normalizes to an empty key and rejects (backport of upstream PR #496) | 2026-09-02 | db33bbd | [260902-erj-fix-etcd-agent-startup-invalid-store-hea](./quick/260902-erj-fix-etcd-agent-startup-invalid-store-hea/) |
+| 260902-hp5 | Fix filekv data race and double-close between Close() and readEvents(); make closeWatchers locked and idempotent; sound pointer receivers (10 copylocks) | 2026-09-02 | ffda1bb | [260902-hp5-fix-filekv-data-race-and-double-close-be](./quick/260902-hp5-fix-filekv-data-race-and-double-close-be/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260902-hp5-fix-filekv-data-race-and-double-close-be/260902-hp5-PLAN.md
+++ b/.planning/quick/260902-hp5-fix-filekv-data-race-and-double-close-be/260902-hp5-PLAN.md
@@ -1,0 +1,243 @@
+---
+phase: 260902-hp5
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - agent/filekv/filekv.go
+  - agent/filekv/filekv_test.go
+autonomous: true
+requirements: [QUICK-260902-hp5]
+
+estimate:
+  tokens: 30000
+  raw_tokens: 20000
+  tasks: 2
+  confidence: low
+
+must_haves:
+  truths:
+    - "go test -race ./agent/filekv/... -count=3 passes, repeated 3 times back to back"
+    - "go vet ./agent/filekv/... exits 0 (it reports 10 copylocks findings on main today)"
+    - "closeWatchers is safe to call from both Close and readEvents, in either order, concurrently"
+    - "closeWatchers is idempotent — a second call closes nothing and panics on nothing"
+    - "Close() called twice returns nil both times and does not panic"
+    - "readEvents returns after the Errors case instead of looping on a closed channel"
+    - "No lock is held across the blocking send to a watcher channel"
+  artifacts:
+    - "agent/filekv/filekv.go — closeWatchers takes w.lock and resets w.watches to an empty map"
+    - "agent/filekv/filekv.go — readEvents copies the watcher slice under w.lock, releases, then sends"
+    - "agent/filekv/filekv.go — every Store method uses a pointer receiver"
+    - "agent/filekv/filekv_test.go — TestClose_Idempotent"
+  key_links:
+    - "closeWatchers resets to an EMPTY MAP, not nil — addWatch and removeWatch both write to w.watches, and a write to a nil map panics"
+    - "The slice copy in readEvents must be a real copy, not a re-slice aliasing the map's backing array"
+    - "close(ch) never blocks, so holding w.lock across the close loop in closeWatchers cannot deadlock — the blocking send in readEvents is the only thing that must stay outside the lock"
+---
+
+<objective>
+Fix the data race and double-close between `filekv`'s `Close()` and its `readEvents()`
+goroutine. All four defects are in `agent/filekv/filekv.go` and all four are one bug's
+blast radius.
+
+Purpose: this is latent CI breakage, not a theory. `go test -race ./agent/filekv/...`
+fails on `main` today, and CI runs `go test -race ./...`. Confirmed locally: every race
+report names `closeWatchers` on both sides — read at `filekv.go:256` from the `readEvents`
+goroutine started by `New` (`filekv.go:82`), previous write at `filekv.go:261` from
+`Close` (`filekv.go:265`). Reports that show `go-git` frames in the stack are the SAME
+bug — those frames are stale garbage on a reused goroutine stack, not a second defect.
+`filekv` is production code: it backs the devserver and dev-mode agent.
+
+Output: a mutex-guarded, idempotent `closeWatchers`; a `readEvents` that reads the map
+under the lock and sends outside it; a terminating `Errors` case; sound receivers; and
+one regression test. Two commits.
+</objective>
+
+<execution_context>
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/workflows/execute-plan.md
+@/Users/smintz/go/src/github.com/protoconf/protoconf/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+@agent/filekv/filekv.go
+@agent/filekv/filekv_test.go
+</context>
+
+<scope_fence>
+IN scope: concurrency correctness inside `agent/filekv/filekv.go`, plus one test in
+`agent/filekv/filekv_test.go`.
+
+OUT of scope, do not touch:
+- The `panic("implement me")` stubs (`Get`, `Delete`, `WatchTree`, `NewLock`, `List`,
+  `DeleteTree`, `AtomicPut`, `AtomicDelete`). STATE.md records this as a standing project
+  decision: "Keep KV store panic stubs: Intentional interface satisfaction". Their
+  *receivers* change in Task 1; their *bodies* do not.
+- `Watch` / `Get` semantics, the `store.Store` contract, anything outside `agent/filekv/`.
+- `go generate`, any `.pb.go` file.
+- `.claude/worktrees/` — it holds a stale copy of this package. Never edit it.
+</scope_fence>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: Make closeWatchers lock-guarded and idempotent, terminate the Errors case, sound the receivers</name>
+  <files>agent/filekv/filekv.go</files>
+  <read_first>
+Read the whole file first — it is 268 lines. Note that `addWatch` (line 200) and
+`removeWatch` (line 213) already do the right thing: `w.lock.Lock()` + `defer
+w.lock.Unlock()`. `closeWatchers` (line 255) does neither, and it both reads and writes
+`w.watches`. Match the existing lock convention exactly; do not introduce an RWMutex, a
+second mutex, `sync.Map`, or an atomic flag.
+  </read_first>
+  <action>
+Four changes, all in `agent/filekv/filekv.go`. Make them together — they are one fix.
+
+1. `closeWatchers`: acquire `w.lock` with `Lock()` + `defer Unlock()` around the entire
+   body, exactly as `addWatch` does. This is the change the race detector is pointing at.
+
+2. `closeWatchers` reset: replace the trailing `w.watches = nil` with an assignment of a
+   fresh empty map of the same type (`make(map[string]([]chan struct{}))`). This is what
+   makes the function idempotent — a second pass ranges an empty map, closes nothing, and
+   cannot double-close. Do NOT keep the nil assignment: `addWatch` does
+   `w.watches[path] = append(...)` and `removeWatch` does `w.watches[path] = ...`, and a
+   write to a nil map panics at runtime. An empty map is the same number of characters and
+   removes that whole panic class. Ranging an empty map and ranging a nil map are both
+   no-ops, so idempotency is preserved either way — the empty map is chosen for the writers.
+
+3. `readEvents`, the `fsnotify.Write` branch: it currently ranges `w.watches[event.Name]`
+   with no lock, racing `addWatch`/`removeWatch`. Guard the map read — but READ THIS
+   CAREFULLY, it is the one place where the obvious fix is wrong. The loop body performs a
+   blocking send `channel <- struct{}{}` on an unbuffered channel. If you hold `w.lock`
+   across that send, a `Watch` consumer that is slow, busy, or gone will block the send
+   forever while holding the store's only mutex, and every `addWatch`, `removeWatch` and
+   `Close` in the process deadlocks behind it. So: take `w.lock`, copy the slice for
+   `event.Name` into a local, release the lock, and only then run the send loop over the
+   local copy. The copy must be a genuine copy (allocate and `copy`, or
+   `append([]chan struct{}(nil), w.watches[event.Name]...)`) — re-slicing the map's value
+   still aliases the backing array that `removeChannel` mutates in place. Prefer an
+   explicit `w.lock.Lock()` / `w.lock.Unlock()` pair around just the copy over a
+   `defer`-based inline function; the surrounding `for`/`select` makes `defer` scope
+   easy to get wrong here.
+
+4. `readEvents`, the `w.fsnotifyWatcher.Errors` case: add the missing `return` after
+   `closeWatchers()`, matching the `Events` `!ok` branch immediately above it. Without it,
+   `fsnotifyWatcher.Close()` closes `Errors` too, that case then fires forever, and the
+   loop spins hot on `closeWatchers` until `select` happens to pick the `Events` branch.
+
+5. Receivers. `go vet ./agent/filekv/...` fails on `main` today with 10 `copylocks`
+   findings — `Store` embeds a `sync.Mutex` and ten methods take it by value, copying the
+   mutex on every call. None of those ten bodies touches `w.lock` or `w.watches` today, so
+   there is no live corruption, but the shape is unsound: one future line added to any of
+   them silently operates on a copy of the lock and the map. Change those ten receivers to
+   pointer receivers, matching `addWatch`/`removeWatch`/`Watch`/`Close`. Nothing else
+   changes: no call site moves, no body is rewritten, the stubs keep panicking. This is
+   safe because only `*Store` is ever used — `New` returns `*Store`, `newStore` returns
+   that same pointer as a `store.Store`, and the only external callers
+   (`agent/agent.go:89`, `devserver/command.go:48`, `test/e2e_test.go:272`) all take the
+   pointer. Do not go further than the receiver token; a sweeping refactor is out of scope.
+
+Leave one `ponytail:` comment above the send loop in `readEvents` recording the residual
+window this fix deliberately does not close: between releasing the lock and completing a
+send, a concurrent `Close` can close the very channel being sent on, which panics. The
+upgrade path is to stop using channel-close as the termination signal and add a single
+shared `done` channel closed once by `Close`, which requires changing `Watch`'s select and
+is out of scope here. Name that ceiling and that path in the comment.
+  </action>
+  <verify>
+    <automated>go build ./... &amp;&amp; go vet ./agent/filekv/... &amp;&amp; go test -race ./agent/filekv/... -count=2 -timeout 10m</automated>
+  </verify>
+  <done>
+`go vet ./agent/filekv/...` exits 0 (it printed 10 copylocks findings before this task).
+`go test -race ./agent/filekv/... -count=2` passes with no `WARNING: DATA RACE`.
+`go build ./...` succeeds. The eight `panic("implement me")` bodies are byte-identical to
+before; only their receiver tokens changed.
+  </done>
+  <reversibility rating="reversible">Confined to one file, no API or wire-format change; `git revert` restores the prior behavior exactly.</reversibility>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Regression test for double-Close, then prove the fix under repetition</name>
+  <files>agent/filekv/filekv_test.go</files>
+  <behavior>
+    - `TestClose_Idempotent`: construct a store via `New` with `testdata.SmallTestDir()`,
+      call `Close()` twice, assert `NoError` on both calls and that neither panics.
+      Second `Close` returning nil is guaranteed by fsnotify v1.7.0, whose
+      `(*Watcher).Close` short-circuits on an already-closed watcher and returns nil on
+      both the kqueue (darwin) and inotify (linux) backends. This test fails against the
+      pre-fix code path that double-closes watcher channels.
+  </behavior>
+  <action>
+Add `TestClose_Idempotent` to `agent/filekv/filekv_test.go`, following the shape of the
+existing `TestClose` immediately above it (same `testdata.SmallTestDir()` +
+`New(ctx, []string{}, &amp;Config{...})` + `require.NoError` construction). Do not use the
+`newTestStore` helper — its `t.Cleanup` calls `Close` a third time, which muddies what
+this test is asserting. Keep it under ten lines. Add nothing else: the existing suite
+already exercises the concurrent path and reproduced the race on every run before the fix,
+so a bespoke concurrency harness here would be redundant.
+
+Then run the verification below. A single green race run does not prove this fix — the
+failure is timing-dependent, so the gate is a repeated run.
+  </action>
+  <verify>
+    <automated>go test -race ./agent/filekv/... -run TestClose_Idempotent -count=1</automated>
+    <automated>for i in 1 2 3; do go test -race ./agent/filekv/... -count=3 -timeout 20m || exit 1; done</automated>
+    <automated>go test -race ./agent/... -count=1 -skip Test_cliCommand_Run -timeout 20m</automated>
+  </verify>
+  <done>
+`TestClose_Idempotent` exists and passes. Three consecutive `-count=3` race runs of
+`./agent/filekv/...` pass with zero `WARNING: DATA RACE` lines. The wider
+`go test -race ./agent/... -count=1 -skip Test_cliCommand_Run` passes.
+
+Budget note for the executor: this package is slow under `-race` — roughly 55s per
+`-count=1` pass, because `testdata.SmallTestDir()` runs a `go-git` PlainInit per test.
+The repetition loop takes about 8 minutes. Give the Bash call a long timeout rather than
+trimming the repetition; a single green run does not prove a timing-dependent fix.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| fs event → store watcher goroutine | fsnotify delivers events on a goroutine the caller does not control; it interleaves with caller-driven `Watch`/`Close` |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-hp5-01 | Denial of Service | `filekv.closeWatchers` | medium | mitigate | Double `close()` on an already-closed watcher channel panics and takes down the whole devserver/dev-agent process. Lock + empty-map reset makes the second pass a no-op. |
+| T-hp5-02 | Denial of Service | `filekv.readEvents` Errors case | medium | mitigate | Missing `return` spins the goroutine hot on a permanently-ready closed channel, burning a core. Task 1 adds the `return`. |
+| T-hp5-03 | Denial of Service | `filekv.readEvents` send loop | medium | accept | Holding the lock across the blocking send would deadlock every store operation behind one slow consumer; the fix copies-then-sends outside the lock. The residual send-on-closed-channel window during a concurrent `Close` is recorded in a `ponytail:` comment with its upgrade path, not closed here — closing it requires changing `Watch`'s termination signal, which is out of scope. |
+
+No new dependency is added, so the package-legitimacy gate does not apply.
+</threat_model>
+
+<verification>
+1. `go build ./...` — succeeds.
+2. `go vet ./agent/filekv/...` — exits 0. Baseline on `main` is 10 `copylocks` findings.
+3. `go test -race ./agent/filekv/... -count=3`, run three times back to back — all pass,
+   zero `WARNING: DATA RACE`. Baseline on `main`: `TestNew_InvalidRoot`, `TestPut`,
+   `TestPut_WithWriteOptions`, `TestExists`, `TestClose` and
+   `TestWatch_ContextCancellation` all report a race at `filekv.go:256` vs `:261`.
+4. `go test -race ./agent/... -count=1 -skip Test_cliCommand_Run` — passes.
+5. `git diff --stat` touches exactly `agent/filekv/filekv.go` and
+   `agent/filekv/filekv_test.go`. No `.pb.go`, nothing under `.claude/worktrees/`.
+</verification>
+
+<success_criteria>
+- The race is gone under repetition, not just on one lucky run.
+- `closeWatchers` is callable twice, from either goroutine, in any order, without panic.
+- No mutex is held across a blocking channel send anywhere in the package.
+- `go vet` is clean on the package for the first time.
+- The `panic("implement me")` stubs still panic; only their receivers changed.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260902-hp5-fix-filekv-data-race-and-double-close-be/260902-hp5-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260902-hp5-fix-filekv-data-race-and-double-close-be/260902-hp5-SUMMARY.md
+++ b/.planning/quick/260902-hp5-fix-filekv-data-race-and-double-close-be/260902-hp5-SUMMARY.md
@@ -1,0 +1,116 @@
+---
+phase: 260902-hp5
+plan: 01
+subsystem: infra
+tags: [filekv, concurrency, data-race, fsnotify, mutex]
+
+requires: []
+provides:
+  - "Lock-guarded, idempotent closeWatchers in agent/filekv/filekv.go"
+  - "readEvents no longer holds w.lock across a blocking channel send"
+  - "readEvents terminates on fsnotifyWatcher.Errors close instead of spinning"
+  - "All ten Store methods use pointer receivers (go vet copylocks clean)"
+  - "TestClose_Idempotent regression test"
+affects: [agent, devserver]
+
+actuals:
+  tokens: 1366
+  tasks: 2
+  commits: 2
+
+tech-stack:
+  added: []
+  patterns: ["copy-under-lock-then-release-then-send for channel fan-out"]
+
+key-files:
+  created: []
+  modified:
+    - agent/filekv/filekv.go
+    - agent/filekv/filekv_test.go
+
+key-decisions:
+  - "closeWatchers resets w.watches to an empty map (not nil) so addWatch/removeWatch never write to a nil map"
+  - "readEvents copies the per-path watcher slice under w.lock, releases, then sends — holding the lock across the blocking send would deadlock every store operation behind one slow Watch consumer"
+  - "Left a ponytail: comment on the residual send-on-closed-channel race between the copy and the send during a concurrent Close, with the documented upgrade path (shared done channel) — explicitly out of scope per plan"
+
+patterns-established:
+  - "Pattern: copy shared-slice-of-channels under the lock, release, then do blocking sends over the local copy — avoids deadlocking the lock behind a slow consumer"
+
+requirements-completed: [QUICK-260902-hp5]
+
+coverage:
+  - id: D1
+    description: "closeWatchers is lock-guarded and idempotent (empty-map reset, no double-close)"
+    requirement: "QUICK-260902-hp5"
+    verification:
+      - kind: unit
+        ref: "go test -race ./agent/filekv/... -count=3 (run 3x back to back)"
+        status: pass
+      - kind: unit
+        ref: "agent/filekv/filekv_test.go#TestClose_Idempotent"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "readEvents copies watcher slice under lock, sends outside lock; Errors case returns instead of spinning"
+    requirement: "QUICK-260902-hp5"
+    verification:
+      - kind: unit
+        ref: "go test -race ./agent/filekv/... -count=3 (run 3x back to back)"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "All ten Store methods use pointer receivers; go vet copylocks clean"
+    requirement: "QUICK-260902-hp5"
+    verification:
+      - kind: other
+        ref: "go vet ./agent/filekv/..."
+        status: pass
+    human_judgment: false
+
+duration: 25min
+completed: 2026-09-02
+status: complete
+---
+
+# Quick Task 260902-hp5: Fix filekv data race and double-close Summary
+
+**Guarded `closeWatchers` with `w.lock`, reset its map to empty (not nil) instead of setting it nil, moved the blocking channel send in `readEvents` outside the lock via a slice copy, added a missing `return` after the `Errors` case, and switched all ten `Store` methods to pointer receivers — eliminating a race the detector caught at `filekv.go:256` vs `:261` on every `main` run.**
+
+## Performance
+
+- **Duration:** 25 min
+- **Tasks:** 2/2 completed
+- **Files touched:** 2 (agent/filekv/filekv.go, agent/filekv/filekv_test.go)
+
+## Accomplishments
+
+- `closeWatchers` now acquires `w.lock` for its entire body (matching `addWatch`/`removeWatch`) and resets `w.watches` to a fresh empty map instead of `nil`, making it safe to call twice from any goroutine without panicking on a subsequent write to a nil map.
+- `readEvents`'s `fsnotify.Write` branch copies the watcher slice for `event.Name` under `w.lock`, releases the lock, then performs the blocking `channel <- struct{}{}` sends over the local copy — so one slow `Watch` consumer can never block every other store operation behind the mutex.
+- `readEvents`'s `Errors` case now `return`s after `closeWatchers()`, matching the `Events` `!ok` branch, so a closed `fsnotifyWatcher.Errors` channel no longer spins the goroutine hot.
+- All ten `Store` value receivers (`Put`, `Get`, `Delete`, `Exists`, `WatchTree`, `NewLock`, `List`, `DeleteTree`, `AtomicPut`, `AtomicDelete`) changed to pointer receivers — `go vet ./agent/filekv/...` went from 10 `copylocks` findings to 0. Method bodies (including the `panic("implement me")` stubs) are unchanged.
+- Added `TestClose_Idempotent`, asserting `Close()` can be called twice with `NoError` both times.
+
+## Deviations from Plan
+
+None — plan executed exactly as written, including the `ponytail:` comment documenting the residual send-on-closed-channel window (out of scope per plan; upgrade path recorded inline).
+
+## Verification (repetition gate)
+
+- `go build ./...` — succeeded.
+- `go vet ./agent/filekv/...` — exit 0 (was 10 copylocks findings before this fix).
+- `go test -race ./agent/filekv/... -count=2 -timeout 10m` (Task 1 gate) — `ok` in 103.9s.
+- `go test -race ./agent/filekv/... -run TestClose_Idempotent -count=1` — `PASS` in 7.4s.
+- Repetition gate `for i in 1 2 3; do go test -race ./agent/filekv/... -count=3 -timeout 20m; done` — all three iterations passed (`ok` in 174.9s, 172.1s, 173.2s respectively), zero `WARNING: DATA RACE` across all 9 total package test runs.
+- `go test -race ./agent/... -count=1 -skip Test_cliCommand_Run -timeout 20m` — all packages `ok` (agent 31.1s, configmaps 2.6s, dummykv 8.7s, filekv 61.2s, otelkv 4.5s).
+- `git diff --stat` against base confirms exactly `agent/filekv/filekv.go` and `agent/filekv/filekv_test.go` changed — no `.pb.go`, nothing under `.claude/worktrees/`.
+
+## Known Stubs
+
+None introduced. The eight `panic("implement me")` stubs (`Get`, `Delete`, `WatchTree`, `NewLock`, `List`, `DeleteTree`, `AtomicPut`, `AtomicDelete`) are pre-existing and intentionally untouched per plan scope — their receivers changed from value to pointer, their bodies did not.
+
+## Self-Check: PASSED
+
+- FOUND: agent/filekv/filekv.go (modified, verified via git diff --stat)
+- FOUND: agent/filekv/filekv_test.go (modified, verified via git diff --stat)
+- FOUND commit 81ff31d (fix: closeWatchers lock/idempotent/receivers)
+- FOUND commit ffda1bb (test: TestClose_Idempotent)

--- a/agent/filekv/filekv.go
+++ b/agent/filekv/filekv.go
@@ -85,25 +85,25 @@ func New(ctx context.Context, endpoints []string, options *Config) (*Store, erro
 }
 
 // Put a value at the specified key.
-func (s Store) Put(ctx context.Context, key string, value []byte, opts *store.WriteOptions) error {
+func (s *Store) Put(ctx context.Context, key string, value []byte, opts *store.WriteOptions) error {
 	return nil
 
 }
 
 // Get a value given its key.
-func (s Store) Get(ctx context.Context, key string, opts *store.ReadOptions) (*store.KVPair, error) {
+func (s *Store) Get(ctx context.Context, key string, opts *store.ReadOptions) (*store.KVPair, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
 // Delete the value at the specified key.
-func (s Store) Delete(ctx context.Context, key string) error {
+func (s *Store) Delete(ctx context.Context, key string) error {
 	// TODO implement me
 	panic("implement me")
 }
 
 // Exists Verify if a Key exists in the store.
-func (s Store) Exists(ctx context.Context, key string, opts *store.ReadOptions) (bool, error) {
+func (s *Store) Exists(ctx context.Context, key string, opts *store.ReadOptions) (bool, error) {
 	return true, nil
 }
 
@@ -159,7 +159,7 @@ func (s *Store) Watch(ctx context.Context, key string, opts *store.ReadOptions) 
 }
 
 // WatchTree watches for changes on child nodes under a given directory.
-func (s Store) WatchTree(ctx context.Context, directory string, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
+func (s *Store) WatchTree(ctx context.Context, directory string, opts *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -167,32 +167,32 @@ func (s Store) WatchTree(ctx context.Context, directory string, opts *store.Read
 // NewLock creates a lock for a given key.
 // The returned Locker is not held and must be acquired with `.Lock`.
 // The Value is optional.
-func (s Store) NewLock(ctx context.Context, key string, opts *store.LockOptions) (store.Locker, error) {
+func (s *Store) NewLock(ctx context.Context, key string, opts *store.LockOptions) (store.Locker, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
 // List the content of a given prefix.
-func (s Store) List(ctx context.Context, directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
+func (s *Store) List(ctx context.Context, directory string, opts *store.ReadOptions) ([]*store.KVPair, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
 // DeleteTree deletes a range of keys under a given directory.
-func (s Store) DeleteTree(ctx context.Context, directory string) error {
+func (s *Store) DeleteTree(ctx context.Context, directory string) error {
 	// TODO implement me
 	panic("implement me")
 }
 
 // AtomicPut Atomic CAS operation on a single value.
 // Pass previous = nil to create a new key.
-func (s Store) AtomicPut(ctx context.Context, key string, value []byte, previous *store.KVPair, opts *store.WriteOptions) (bool, *store.KVPair, error) {
+func (s *Store) AtomicPut(ctx context.Context, key string, value []byte, previous *store.KVPair, opts *store.WriteOptions) (bool, *store.KVPair, error) {
 	// TODO implement me
 	panic("implement me")
 }
 
 // AtomicDelete Atomic delete of a single value.
-func (s Store) AtomicDelete(ctx context.Context, key string, previous *store.KVPair) (bool, error) {
+func (s *Store) AtomicDelete(ctx context.Context, key string, previous *store.KVPair) (bool, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -242,23 +242,38 @@ func (w *Store) readEvents() {
 				return
 			}
 			if event.Op&fsnotify.Write == fsnotify.Write {
-				for _, channel := range w.watches[event.Name] {
+				w.lock.Lock()
+				channels := append([]chan struct{}(nil), w.watches[event.Name]...)
+				w.lock.Unlock()
+
+				// ponytail: a concurrent Close can close one of these channels
+				// between the unlock above and the send below, which panics.
+				// Ceiling: fine under normal operation, since Close() is
+				// typically called once at shutdown. Upgrade path: replace
+				// channel-close-as-signal with a single shared `done` channel
+				// closed once by Close, and have Watch's select read from it
+				// instead of relying on a closed per-watch channel.
+				for _, channel := range channels {
 					channel <- struct{}{}
 				}
 			}
 		case <-w.fsnotifyWatcher.Errors:
 			w.closeWatchers()
+			return
 		}
 	}
 }
 
 func (w *Store) closeWatchers() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
 	for _, pathWatches := range w.watches {
 		for _, watch := range pathWatches {
 			close(watch)
 		}
 	}
-	w.watches = nil
+	w.watches = make(map[string]([]chan struct{}))
 }
 
 func (w *Store) Close() error {

--- a/agent/filekv/filekv_test.go
+++ b/agent/filekv/filekv_test.go
@@ -83,6 +83,17 @@ func TestClose(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestClose_Idempotent(t *testing.T) {
+	root := testdata.SmallTestDir()
+	ctx := context.Background()
+	s, err := New(ctx, []string{}, &Config{ProtoconfRoot: root})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	assert.NoError(t, s.Close())
+	assert.NoError(t, s.Close())
+}
+
 func TestWatch_InvalidPath(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Pre-existing concurrency bug in `agent/filekv`, found while adding `filekv` tests in #528. `go test -race ./agent/filekv/... -count=1` **fails on `main` today**:

```
--- FAIL: TestNew_InvalidRoot
--- FAIL: TestPut
--- FAIL: TestPut_WithWriteOptions
--- FAIL: TestClose
```

CI runs `go test -race ./...`, so this is latent CI breakage that currently fires only intermittently. #528's added tests create enough `Store` instances to make it fire reliably — which is how it surfaced.

This is production code: `filekv` backs the devserver and dev-mode agent.

## Four defects, one root cause

`closeWatchers` mutated shared state with no lock, even though `addWatch`/`removeWatch` in the same file both correctly take `w.lock`.

1. **Unsynchronized access** — `closeWatchers` reads *and nils* `w.watches` unlocked. The race detector names it on both sides: read from the `readEvents` goroutine, previous write from `Close`.
2. **Double close** — `Close()` calls `closeWatchers()`, then `fsnotifyWatcher.Close()`, which closes the `Events` channel, which drives `readEvents` into `closeWatchers()` a *second* time. If the nil-ing hasn't landed, `close(watch)` runs twice on the same channel and panics.
3. **`readEvents` read `w.watches[event.Name]` unlocked** in the Write branch, racing with `addWatch`/`removeWatch`.
4. **The `Errors` case never returned**, so after `Close()` it could spin on the now-closed channel.

## Fix

`closeWatchers` now takes `w.lock` and is idempotent. Note it resets to a **fresh empty map** rather than `nil` — `addWatch`/`removeWatch` both *write* to `w.watches`, and a write to a nil map panics, so the old `= nil` left a live nil-map-write panic behind even once the race was fixed. Same size, removes the whole class.

`readEvents` copies the channel slice **under** the lock and sends **after** releasing it. Holding the lock across the blocking `channel <- struct{}{}` would deadlock the entire store on one slow or departed `Watch` consumer.

The `Errors` case now returns.

## Receivers: `go vet` was already failing

`go vet ./agent/filekv/...` reports **10 `copylocks` findings** on `main` — `Store` embeds a `sync.Mutex` but ten methods took it by value. None of those bodies touches the lock or map today, so nothing is corrupt right now, but it is unsound by construction.

Fixed by changing the receiver token on those ten lines. **Zero call-site churn** — only `*Store` is ever constructed (`agent/agent.go`, `devserver/command.go`, `test/e2e_test.go` all take the pointer). Not a sweeping refactor.

## Known remaining ceiling, marked in-code

Copy-then-send outside the lock is mandatory (see above), but it leaves a narrow window where a concurrent `Close` can close a channel mid-send, which panics. Fine in normal operation — `Close()` is called once at shutdown. Closing it properly means replacing channel-close-as-termination-signal with a shared `done` channel and reworking `Watch`'s select, which is a bigger change than this fix warrants. Recorded as a `ponytail:` comment naming the ceiling and the upgrade path rather than silently shipped.

## Verification — a repetition gate, not one green run

The failure is timing-dependent, so a single pass proves nothing.

```
go build ./...                                          OK
go vet ./agent/filekv/...                               clean (was 10 copylocks findings)
go test -race ./agent/filekv/... -count=3   ×3 runs     9 runs, zero DATA RACE
go test -race ./agent/filekv/... -count=2               ok, zero DATA RACE
go test -race ./agent/... -skip Test_cliCommand_Run     all pass
```

Plus a new `TestClose_Idempotent` regression test — fsnotify v1.7.0's `Close` is itself idempotent, so it asserts `NoError` on both calls rather than merely "does not panic".

## Merge order

**This should merge before #528.** #528 and #529 are red on this race alone; they go green once this lands and they rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msxscm8fhgmYuPcYQwFTjZ