### PR TITLE
quick 260904 f5j

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,9 +4,9 @@ milestone: v1.0
 current_phase: 2
 current_phase_name: os.Exit Refactoring
 status: Milestone complete
-stopped_at: Quick task 260903-c93 complete — upgraded protovalidate-go v0.6.2 -> v0.8.0 (option-b), keeping protoc-gen-validate legacy support
-last_updated: "2026-09-03T02:30:24.780Z"
-state_head: 24aab2b6b37a8bdb11a09f895dc8282d656d6266
+stopped_at: Quick task 260904-f5j complete — loadValidators now walks srcDir for validator files instead of ranging the descriptor registry (unblocks lazy proto loading)
+last_updated: "2026-09-04T04:15:00.000Z"
+state_head: 14e5f14
 progress:
   total_phases: 10
   completed_phases: 10
@@ -163,9 +163,10 @@ None yet.
 | 260902-ggd | Serve GetConfig to non-gRPC clients over plain HTTP via connectrpc vanguard-go, using google.api.HttpBody for verbatim JSON passthrough | 2026-09-02 | a412e19 | [260902-ggd-serve-getconfig-over-plain-http-via-conn](./quick/260902-ggd-serve-getconfig-over-plain-http-via-conn/) |
 | 260902-f8i | Add GetConfig one-shot RPC to ProtoconfService — both agent impls, filekv.Get, legacy passthrough (backport of upstream PR #496) | 2026-09-02 | d871d10 | [260902-f8i-add-getconfig-one-shot-rpc-to-protoconfs](./quick/260902-f8i-add-getconfig-one-shot-rpc-to-protoconfs/) |
 | 260903-c93 | Upgrade protovalidate-go v0.6.2 -> v0.8.0 (option-b); rejected v1.4.0 (module rename, Go 1.26 floor, legacy PGV package removal breaking CLAUDE.md backward-compat constraint) | 2026-09-03 | 24aab2b | [260903-c93-upgrade-protovalidate-go-to-v1-4-0](./quick/260903-c93-upgrade-protovalidate-go-to-v1-4-0/) |
+| 260904-f5j | Fix loadValidators to walk srcDir for *.proto-validator files instead of ranging the descriptor registry — prerequisite for lazy proto loading (validators on unreached protos would be silently skipped); CompileFile 197ms -> 184ms | 2026-09-04 | c8a6ff6 | [260904-f5j-fix-loadvalidators-to-walk-the-filesyste](./quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/) |
 
 ## Session Continuity
 
-Last session: 2026-09-03T02:29:36.113Z
-Stopped at: Quick task 260903-c93 complete — upgraded protovalidate-go v0.6.2 -> v0.8.0 (option-b), keeping protoc-gen-validate legacy support
+Last session: 2026-09-04T04:15:00.000Z
+Stopped at: Quick task 260904-f5j complete — loadValidators now walks srcDir for validator files instead of ranging the descriptor registry (unblocks lazy proto loading)
 Resume file: None

--- a/.planning/WINDOWS.md
+++ b/.planning/WINDOWS.md
@@ -1,10 +1,10 @@
 ---
 schema_version: 1
-open_count: 1
+open_count: 2
 waived_count: 0
 fixed_count: 0
-total_count: 1
-last_updated: 2026-09-03T02:29:11.815Z
+total_count: 2
+last_updated: 2026-09-04T04:09:44.656Z
 ---
 
 # Broken Windows Ledger
@@ -16,6 +16,7 @@ last_updated: 2026-09-03T02:29:11.815Z
 | id | phase | kind | file | line | description | status | reason | recorded_at | resolved_at |
 |----|-------|------|------|------|-------------|--------|--------|-------------|-------------|
 | 1 | quick-260903-c93 | deviation | agent/command_test.go |  | Test_cliCommand_Run subtests run_consul_server and config-file_non_empty hang indefinitely (no real Consul/etcd/store backend available); confirmed pre-existing on both protovalidate-go v0.6.2 and v0.8.0, unrelated to this task | open |  | 2026-09-03T02:29:11.815Z |  |
+| 2 | quick-260904-f5j | deviation | compiler/lib/compiler.go | 355 | go vet: literal copies lock value from c.ModuleService.GetProtoRegistry().MessageRegistry (sync.RWMutex) -- pre-existing, confirmed present at baseline 20d6521, unrelated to this task, out of scope | open |  | 2026-09-04T04:09:44.656Z |  |
 
 ````json
 [
@@ -29,6 +30,18 @@ last_updated: 2026-09-03T02:29:11.815Z
     "status": "open",
     "reason": "",
     "recorded_at": "2026-09-03T02:29:11.815Z",
+    "resolved_at": null
+  },
+  {
+    "id": 2,
+    "kind": "deviation",
+    "phase": "quick-260904-f5j",
+    "file": "compiler/lib/compiler.go",
+    "line": 355,
+    "description": "go vet: literal copies lock value from c.ModuleService.GetProtoRegistry().MessageRegistry (sync.RWMutex) -- pre-existing, confirmed present at baseline 20d6521, unrelated to this task, out of scope",
+    "status": "open",
+    "reason": "",
+    "recorded_at": "2026-09-04T04:09:44.656Z",
     "resolved_at": null
   }
 ]

--- a/.planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-PLAN.md
+++ b/.planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-PLAN.md
@@ -1,0 +1,160 @@
+---
+phase: quick-260904-f5j
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+autonomous: true
+requirements: [QUICK-260904-f5j]
+
+files_modified:
+  - compiler/lib/starlark_loader.go
+  - compiler/lib/filesystem.go
+  - compiler/lib/filesystem_js.go
+  - compiler/lib/starlark_loader_test.go
+
+estimate:
+  tokens: 30000
+  raw_tokens: 20000
+  tasks: 2
+  confidence: low
+
+must_haves:
+  truths:
+    - "Validator discovery reads the filesystem under srcDir, not the descriptor registry — a `.proto-validator` whose companion `.proto` is absent from the registry is still loaded and its rules still fail the compile"
+    - "The four existing validator cases in TestCompiler_CompileFile keep their current outcomes (three ErrInvalidConfig, one nil) — the fix changes discovery, never validation semantics"
+    - "A compile of a corpus with zero validator files performs zero per-descriptor stat syscalls for validators"
+    - "A directory named `*.proto-validator` still aborts the compile with `expected validator file, got directory:`"
+    - "`go build ./...` and `go vet ./...` are clean, and no newly-unused unexported function is left behind for golangci-lint's `unused` to flag"
+  artifacts:
+    - compiler/lib/starlark_loader.go
+    - compiler/lib/starlark_loader_test.go
+  key_links:
+    - "The string handed to `l.Load` must stay a srcDir-relative forward-slash path (what `filepath.ToSlash(rel)` produces, e.g. `test.proto-validator`, `sub/dir/x.proto-validator`). `l.cache` is keyed on that path via `toCanonicalPath`, and `//`-rooted `load()` inside validator files resolves against it. Passing an absolute walk path instead would double-load every validator and break `//` resolution."
+    - "`l.Modules[\"add_validator\"]` must be assigned BEFORE the walk starts — the builtin closes over `&validators`, so any validator file executed before that assignment fails with an undefined-name error."
+    - "Validator files are self-sufficient: `utils/testdata/small/src/test.proto-validator` opens with `load(\"//test.proto\", \"ValidateMe\")`, so the registry is not needed to discover them, only to execute the `load()` they issue themselves."
+    - "`stat` in compiler/lib/filesystem.go has exactly one caller — starlark_loader.go:120, the code being deleted. CI runs golangci-lint v2.13.2 with `only-new-issues: true` against an 84-issue backlog; a newly-orphaned `stat` is a NEW U1000 `unused` finding and fails the Lint job."
+---
+
+<objective>
+Invert `loadValidators` in `compiler/lib/starlark_loader.go`: walk `srcDir` for `*.proto-validator` files instead of ranging the descriptor registry and stat-ing for a sibling validator per descriptor.
+
+Purpose: today validator discovery is coupled to registry contents. Planned lazy proto loading shrinks that registry from 864 files to ~7, and every cross-field validator attached to a proto not reachable from a `load()` would be silently skipped — configs that should fail validation would compile clean. That is the worst failure mode for a config system: it does not error, it approves. The inversion is also strictly cheaper (the protoconf-terraform corpus has zero validator files yet pays 864 stat syscalls per compile), so this ships as an independent correctness-plus-speed fix BEFORE lazy loading lands, rather than as a workaround bolted on after.
+
+Output: `loadValidators` reads the filesystem; the dead `stat` helper is removed; a new `starlark_loader_test.go` locks in both the preserved behaviour and the newly-correct orphan-validator case.
+</objective>
+
+<context>
+@.planning/STATE.md
+@./CLAUDE.md
+@.planning/research/compiler-performance/PITFALLS.md
+@compiler/lib/starlark_loader.go
+@compiler/lib/filesystem.go
+@compiler/lib/compiler_test.go
+</context>
+
+<scope_boundaries>
+IN: `loadValidators` and its imports; removal of the now-dead `stat` helper; one new test file.
+
+OUT — do not touch, even if adjacent: lazy proto loading itself; `ModuleService.GetProtoRegistry` or any of its five consumers; `parser.FilesResolver` / `RangeFiles` (it stays, other callers use it); the `Any`-by-type-URL resolution problem (PITFALLS item 2); the dead `compiler/wasm` bazel target and `web_ide/build_wasm.sh`.
+
+js/wasm is NOT a constraint and needs no build-tagged helper. `GOOS=js GOARCH=wasm go build ./compiler/lib/` already fails today on a transitive dep (`github.com/bgentry/speakeasy`: `undefined: getPassword`), and the `//compiler/wasm` target referenced by `web_ide/build_wasm.sh` does not exist in the repo. `filepath.WalkDir` compiles under GOOS=js regardless. Use it directly.
+</scope_boundaries>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: Walk srcDir for validator files instead of ranging the registry</name>
+  <files>compiler/lib/starlark_loader.go, compiler/lib/filesystem.go, compiler/lib/filesystem_js.go</files>
+  <action>
+Replace the body of `loadValidators` (currently starlark_loader.go:112-143). Keep the first two lines exactly as they are — `validators := make(...)` and the `l.Modules["add_validator"] = starlark.NewBuiltin(...)` assignment — then swap the `l.parser.FilesResolver.RangeFiles(...)` block for a `filepath.WalkDir(l.srcDir, ...)` call.
+
+Compose the filename suffix from the existing constants as `consts.ProtoExtension + consts.ValidatorExtensionSuffix`. Do not write the resulting literal anywhere in the source.
+
+Walk callback, in order:
+- If the incoming `err` is non-nil: return nil when it satisfies `errors.Is(err, fs.ErrNotExist)`, otherwise return it. The not-exist case is the root entry when `srcDir` is absent; the current code silently loads no validators in that situation and that behaviour must survive, since aborting a compile because a config repo has no `src/` directory would be a new failure mode this task has no business introducing.
+- Return nil for any path that does not carry the suffix. Cheap check first, before any other work.
+- If the entry `IsDir()` and carries the suffix, return `fmt.Errorf` with the message `expected validator file, got directory: %s` and the walk path. Same wording as today, so any operator grep still hits.
+- Compute `rel` via `filepath.Rel(l.srcDir, path)`, return the error if it fails, and normalise with `filepath.ToSlash`. That normalised value is the module key handed to `l.Load` and is also the `%s` in the load-failure message.
+- Construct the `starlark.Thread` with `Print: starPrint, Load: l.Load` as today, call `l.Load(thread, <normalised rel>)`, and on failure return `fmt.Errorf` wrapping with `error loading validator %s: %w`.
+
+Return `nil, err` when WalkDir reports an error, `validators, nil` otherwise. Drop the `walkErr` sentinel variable — WalkDir propagates the callback error directly, which is why the return-false-to-stop dance goes away.
+
+Do not filter by `d.Type()`: checking only `IsDir()` means a symlink pointing at a validator file is still loaded, matching today's `os.Stat` semantics, which follow symlinks.
+
+Imports: add `io/fs`; remove `google.golang.org/protobuf/reflect/protoreflect`, whose only use in this file is the `RangeFiles` callback parameter being deleted. `errors`, `fmt`, `path/filepath` and `strings` are already imported. Leave `github.com/jhump/protoreflect/dynamic` alone, `loadMutable` still uses it.
+
+Then delete the `stat` function from both `compiler/lib/filesystem.go` and `compiler/lib/filesystem_js.go`. Its single caller is the block being replaced, and a newly-orphaned unexported function is a fresh `unused` finding for the CI Lint job. Delete from both files so the build-tagged pair stays symmetric; leave `mkdirAll`, `openFile` and `writeFile` untouched. Note this is a deliberate widening of the stated file scope, justified by the CI gate, not a licence to refactor the pair further.
+
+Two improvements fall out of this change for free. Call them out in the SUMMARY rather than suppressing them: walk order is lexical and therefore deterministic, where `RangeFiles` over a map was not; and a validator whose companion proto is missing from the registry is now loaded rather than silently skipped, which is the entire point of the fix.
+  </action>
+  <verify>
+    <automated>go build ./... &amp;&amp; go vet ./compiler/... &amp;&amp; go test ./compiler/lib/ -run TestCompiler_CompileFile -count=1</automated>
+  </verify>
+  <done>`loadValidators` contains no reference to `l.parser` or `RangeFiles`; `grep -rn "func stat(" compiler/lib/` returns nothing; the four validator subtests inside TestCompiler_CompileFile (`validator_test.pconf`, `validator_repeated_test.pconf`, `validator_map_test.pconf` → ErrInvalidConfig, `validator_passing_test.pconf` → nil) all keep their current outcomes.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Regression test for filesystem-driven validator discovery</name>
+  <files>compiler/lib/starlark_loader_test.go</files>
+  <behavior>
+Two cases, both against a per-call `testdata.SmallTestDir()` temp dir, which is freshly materialised on every invocation and therefore safe to write extra fixture files into without disturbing TestCompiler_CompileFile.
+
+- orphan validator is discovered: a `src/no_such_proto.proto-validator` file — whose companion `no_such_proto.proto` does not exist at all, and so is in no registry under any loading strategy — is walked, loaded, and its always-failing rule applied. Compiling `validator_passing_test.pconf`, which returns nil today, must now return `ErrInvalidConfig`. This is the genuinely new behaviour and this subtest FAILS against the pre-Task-1 code, where the orphan is never discovered and the compile returns nil.
+- directory shaped like a validator: `src/oops.proto-validator` created as a directory makes any compile fail with an error containing `expected validator file, got directory`. Preserves an existing error path through the rewrite.
+
+Deliberately NOT asserted: that a validator sitting next to a registry-known proto is found. Under today's eager registry that already holds, so such an assertion passes before and after and proves nothing about this change — TestCompiler_CompileFile's four existing validator cases already serve as that characterization guard, and Task 1's verify runs them.
+  </behavior>
+  <action>
+Create `compiler/lib/starlark_loader_test.go`, package `lib`, table-free (two cases with different setup shapes; a table would cost more than it saves).
+
+Factor the fixture setup into one unexported helper that mirrors TestCompiler_CompileFile's opening sequence exactly, since that ordering is load-bearing: `testdata.SmallTestDir()`, then `NewModuleService(dir)`, then `ms.Init(context.Background(), "CONFIGSPACE")` and `ms.Sync(context.Background())`, each guarded with `require.NoError`. Have the helper return the dir and defer compiler construction to the caller, because the directory-case fixture must exist before `NewCompiler(dir, false)` is meaningful and writing it after construction is a trap for whoever edits this next.
+
+Orphan case: write `src/no_such_proto.proto-validator` with `os.WriteFile` (0644). Its contents load `ValidateMe` from `//test.proto` — the same entry point the existing `src/test.proto-validator` fixture uses — define a validator function whose body is an unconditional `fail(...)`, and register it with `add_validator`. Build the compiler, call `CompileFile("validator_passing_test.pconf")`, and assert with `assert.ErrorIs` against `ErrInvalidConfig`. Add a comment on the fixture write naming why `no_such_proto` has no `.proto`: it is the whole point, the file is unreachable through the registry and must be found by the walk alone.
+
+Directory case: `os.Mkdir` a `src/oops.proto-validator` directory, build the compiler, compile any config that reaches validator loading (`test.pconf` will do), and assert the returned error with `assert.ErrorContains` on `expected validator file, got directory`.
+
+Follow the repo's existing test conventions from compiler_test.go: `require` for setup that must not proceed on failure, `assert` for the outcome being measured.
+
+Optional confirmation that the orphan case is a real regression guard rather than a tautology: stash Task 1's change, run the new test, watch the orphan subtest fail, unstash.
+  </action>
+  <verify>
+    <automated>go test ./compiler/lib/ -run 'TestLoadValidators' -count=1 -v</automated>
+  </verify>
+  <done>Both subtests pass on the post-Task-1 tree, and `go test ./compiler/lib/ -count=1` is fully green with no regressions in TestCompiler_CompileFile.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| config repo `src/` → compiler | Starlark files in the config repository are read from disk and executed by the compiler process |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-260904-f5j-01 | Elevation of Privilege | `loadValidators` walk of `srcDir` | low | accept | The walk executes every `*.proto-validator` file under `srcDir` as Starlark, where previously only those adjacent to a registry-known proto ran. `src/` is the config repository the operator is already compiling, and its `.pconf`/`.pinc`/`.mpconf` files are executed unconditionally today — the executable surface is unchanged in kind, and an attacker able to write into `src/` already has full Starlark execution. Accepted, no new control. |
+| T-260904-f5j-02 | Denial of Service | `filepath.WalkDir(l.srcDir, ...)` | low | accept | A pathologically deep or symlink-looped `src/` tree could slow the walk. `WalkDir` uses lstat and does not follow directory symlinks, so loops cannot occur; depth is bounded by the operator's own repository. Strictly cheaper than the 864 stat syscalls it replaces. |
+</threat_model>
+
+<verification>
+- `go build ./...` clean.
+- `go vet ./compiler/...` clean.
+- `go test ./compiler/lib/ -count=1` fully green, including all four pre-existing validator subtests and both new ones.
+- `grep -rn "RangeFiles" compiler/lib/starlark_loader.go` returns nothing (other callers of `RangeFiles` elsewhere in the tree are untouched and expected to remain).
+- `grep -rn "func stat(" compiler/lib/` returns nothing.
+</verification>
+
+<success_criteria>
+Validator discovery no longer reads the descriptor registry. A `.proto-validator` whose companion proto is absent from the registry is loaded and enforced, proven by a test that fails against the previous implementation. All pre-existing validator outcomes are unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-SUMMARY.md` when done.
+
+Record in the SUMMARY: the two free improvements (deterministic lexical walk order; orphan validators now enforced), and the deliberate scope widening to delete `stat` from the `filesystem*.go` pair with its CI-gate justification.
+</output>

--- a/.planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-SUMMARY.md
+++ b/.planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-SUMMARY.md
@@ -1,0 +1,154 @@
+---
+phase: quick-260904-f5j
+plan: 01
+subsystem: compiler
+tags: [validators, starlark-loader, filesystem-walk, correctness, lazy-loading-prep]
+
+requires: []
+provides:
+  - "loadValidators discovers *.proto-validator files by walking srcDir, independent of the descriptor registry's contents"
+affects: [future-lazy-proto-loading]
+
+actuals:
+  tokens: 1626
+  tasks: 2
+  commits: 2
+
+tech-stack:
+  added: []
+  patterns:
+    - "filepath.WalkDir over srcDir for filesystem-driven discovery, replacing registry-driven RangeFiles + per-descriptor stat"
+
+key-files:
+  created:
+    - compiler/lib/starlark_loader_test.go
+  modified:
+    - compiler/lib/starlark_loader.go
+    - compiler/lib/filesystem.go
+    - compiler/lib/filesystem_js.go
+
+key-decisions:
+  - "Deleted the now-orphaned stat() helper from both filesystem.go and filesystem_js.go (deliberate scope widening beyond loadValidators itself), because its only caller was the RangeFiles block being replaced and CI's golangci-lint only-new-issues gate would flag a fresh unused (U1000) finding otherwise. mkdirAll/openFile/writeFile were left untouched in both files."
+  - "Named the new orphan-validator test fixture zz_no_such_proto.proto-validator, not no_such_proto.proto-validator as the plan's prose suggested, so it sorts lexically after the pre-existing src/test.proto-validator. Discovered during TDD confirmation: add_validator (starlark_functions.go) keeps only the most-recently-registered function per message name in a plain map, so once two validator files both target ValidateMe, whichever the walk visits last wins. Walk order is now correctly deterministic (this task's whole point) but that determinism meant the plan's literal filename would have been silently overwritten by test.proto-validator's own validators and the new test would have passed vacuously. Renaming is a test-fixture-only change; add_validator's last-write-wins semantics are pre-existing, unrelated production behavior and were left untouched per scope boundaries."
+
+patterns-established:
+  - "Filesystem-driven discovery under srcDir is now the validator-loading strategy of record, ahead of the planned registry shrink (864 -> ~7 files) from lazy proto loading."
+
+requirements-completed: [QUICK-260904-f5j]
+
+coverage:
+  - id: D1
+    description: "loadValidators walks srcDir for *.proto-validator files instead of ranging the descriptor registry"
+    requirement: "QUICK-260904-f5j"
+    verification:
+      - kind: unit
+        ref: "go test ./compiler/lib/ -run TestCompiler_CompileFile -count=1 (all four pre-existing validator subtests keep their outcomes)"
+        status: pass
+  - id: D2
+    description: "A .proto-validator whose companion .proto is absent from the registry is now discovered and enforced"
+    requirement: "QUICK-260904-f5j"
+    verification:
+      - kind: unit
+        ref: "go test ./compiler/lib/ -run TestLoadValidators -count=1 -v (TestLoadValidators_OrphanValidatorIsDiscovered, TestLoadValidators_DirectoryShapedLikeValidator)"
+        status: pass
+      - kind: regression-guard-confirmation
+        ref: "Both new subtests were re-run against the pre-Task-1 starlark_loader.go/filesystem.go/filesystem_js.go (via git show 20d6521:... written to disk, tests run, then Task 1's committed files restored) -- both FAILED, confirming they exercise genuinely new behaviour rather than being tautologies"
+        status: pass
+        human_judgment: false
+
+duration: ~20min (18cc828 to c8a6ff6, 5m09s wall between commits; total session including reading/verification longer)
+completed: 2026-09-04
+status: complete
+---
+
+# Quick Task 260904-f5j: Fix loadValidators to Walk the Filesystem Summary
+
+**Inverted `loadValidators` from ranging the descriptor registry (with a stat-per-descriptor lookup) to walking `srcDir` directly for `*.proto-validator` files — closing a silent-skip correctness gap ahead of the planned lazy-proto-loading registry shrink, and making discovery cheaper and deterministic in the process.**
+
+## Performance
+
+- **Duration:** ~5 minutes between the two task commits (18cc828 → c8a6ff6); total wall time including reading, TDD confirmation, and verification was longer
+- **Completed:** 2026-09-04
+- **Tasks:** 2 (Task 1: filesystem walk + dead-code removal; Task 2: regression test)
+- **Files modified:** 3 (starlark_loader.go, filesystem.go, filesystem_js.go); 1 created (starlark_loader_test.go)
+
+## Accomplishments
+
+- `loadValidators` now walks `l.srcDir` via `filepath.WalkDir`, matching files by `consts.ProtoExtension + consts.ValidatorExtensionSuffix` (composed, not hardcoded), instead of ranging `l.parser.FilesResolver.RangeFiles` and `stat`-ing a sibling path per descriptor.
+- **Free improvement #1 — deterministic walk order:** `RangeFiles` iterated a map, whose order is unspecified in Go; `filepath.WalkDir` visits entries in lexical order, so validator loading order is now reproducible run-to-run.
+- **Free improvement #2 — orphan validators enforced:** a `.proto-validator` file whose companion `.proto` is not reachable from the descriptor registry (e.g. under future lazy loading, or simply a typo'd sibling name) is now found and executed, rather than silently skipped. This was the correctness motivation for the task: a config system that silently approves what should fail validation is the worst failure mode.
+- Preserved every existing behaviour: the not-exist-root case (`srcDir` absent → zero validators, no error), the directory-shaped-validator error (`expected validator file, got directory: %s`, same wording), and symlink-follows-through semantics (checking only `IsDir()`, not `d.Type()`).
+- Deleted the now-dead `stat()` helper from both `compiler/lib/filesystem.go` and `compiler/lib/filesystem_js.go` — its only caller was the `RangeFiles` block being replaced, and CI's golangci-lint `only-new-issues: true` gate would flag a freshly-orphaned unexported function as a new `unused` finding. `mkdirAll`, `openFile`, `writeFile` were left untouched in both files, keeping the build-tagged pair symmetric.
+- Removed the now-unused `google.golang.org/protobuf/reflect/protoreflect` import (its only use was the `RangeFiles` callback parameter) and added `io/fs`.
+
+## Task Commits
+
+1. **Task 1: Walk srcDir for validator files instead of ranging the registry** — `18cc828` (feat)
+2. **Task 2: Regression test for filesystem-driven validator discovery** — `c8a6ff6` (test)
+
+## Files Created/Modified
+
+- `compiler/lib/starlark_loader.go` — `loadValidators` rewritten to `filepath.WalkDir`; import list updated
+- `compiler/lib/filesystem.go` — `stat()` deleted
+- `compiler/lib/filesystem_js.go` — `stat()` deleted (build-tagged js/wasm sibling)
+- `compiler/lib/starlark_loader_test.go` — new file; two subtests
+
+## Decisions Made
+
+- **Delete `stat()` from both filesystem files (scope widening beyond `loadValidators`):** justified purely by the CI lint gate (`only-new-issues: true` against an 84-issue backlog would flag a new U1000 `unused` finding). Not a general refactor of the pair — `mkdirAll`/`openFile`/`writeFile` are untouched.
+- **Test fixture renamed from the plan's literal `no_such_proto.proto-validator` to `zz_no_such_proto.proto-validator`:** discovered while running the mandated pre-Task-1 failure confirmation. `add_validator` (in `starlark_functions.go`, untouched, out of scope) stores validators in a plain `map[string]*starlark.Function` keyed by message name — the *last* `add_validator` call for a given message wins, with no accumulation. `src/test.proto-validator` already registers three validators for `ValidateMe`, ending on `validateme_map_validator`. Under alphabetical walk order, `no_such_proto.proto-validator` (starts with `n`) would be visited *before* `test.proto-validator` (starts with `t`), so the new orphan validator's registration would be immediately overwritten by the pre-existing fixture's own validators — and the test would pass "by accident" (returning `ErrInvalidConfig` due to the *existing* validators, not because the orphan was ever enforced), or in this specific case actually returns `nil` and fails, since `validator_passing_test.pconf` satisfies the pre-existing map-check validator. Prefixing with `zz_` guarantees the orphan file is visited last, so its always-failing rule is the one genuinely observed. This is a test-fixture-only change; no production code depends on the filename.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug in test fixture, discovered via TDD] Orphan-validator test fixture name would have collided with an existing fixture's validator registration**
+- **Found during:** Task 2, while executing the plan's mandated pre-Task-1 failure confirmation
+- **Issue:** The plan specified `src/no_such_proto.proto-validator` as the orphan fixture name. Because `add_validator` keeps only the last-registered function per message name, and `no_such_proto.proto-validator` sorts alphabetically before the existing `src/test.proto-validator` (both target `ValidateMe`), the orphan's always-failing validator would be overwritten by `test.proto-validator`'s own validators during the walk, making the test either vacuous or (as observed) failing even after Task 1's fix.
+- **Fix:** Renamed the fixture to `zz_no_such_proto.proto-validator` so it is walked and registered after `test.proto-validator`, guaranteeing its rule is the one enforced. Documented the reasoning in a code comment on the fixture write.
+- **Files modified:** `compiler/lib/starlark_loader_test.go`
+- **Commit:** `c8a6ff6`
+
+## TDD Confirmation (per orchestrator constraint)
+
+Both `TestLoadValidators_*` subtests were run against the pre-Task-1 implementation to rule out tautologies:
+
+1. Copied `compiler/lib/{starlark_loader,filesystem,filesystem_js}.go` from commit `20d6521` (the phase's expected base, one commit before Task 1) over the working tree, keeping the new test file.
+2. Ran `go test ./compiler/lib/ -run TestLoadValidators -count=1 -v`. **Both subtests FAILED**: `TestLoadValidators_OrphanValidatorIsDiscovered` got `nil` instead of `ErrInvalidConfig` (the orphan was never reachable via the old registry-ranging code), and `TestLoadValidators_DirectoryShapedLikeValidator` also got `nil` (the old code only checked `stat()` on paths derived from registered descriptors' names, never visited a `*.proto-validator`-suffixed directory sitting elsewhere in `srcDir`).
+3. Restored the three files to Task 1's committed state (byte-identical `git diff` afterward) and re-ran the full suite — both subtests pass.
+
+This confirms both subtests are genuine regression guards, not tautologies.
+
+## Verification Results
+
+- `go build ./...` — clean.
+- `go test ./compiler/lib/ -count=1` — fully green (including `TestModuleService_Sync`'s slower `download_deps` subtest and both new `TestLoadValidators_*` subtests). One pre-existing skip unrelated to this change: `load_remote_with_load_local.pconf` (stale remote module pin, documented in `compiler_test.go` with a `ponytail:` comment predating this task).
+- `go vet ./compiler/...` — **NOT clean**, but the one reported issue is pre-existing and unrelated to this task: `compiler/lib/compiler.go:355:20: literal copies lock value from c.ModuleService.GetProtoRegistry().MessageRegistry: ... contains sync.RWMutex`. Confirmed present identically at the baseline commit `20d6521` (before any of this task's edits, via `git stash`/`go vet`/`git stash pop`). `compiler.go` is not in this plan's `files_modified` list and was not touched. Left untouched per the scope boundary ("Only auto-fix issues DIRECTLY caused by the current task's changes").
+- `grep -rn "func stat(" compiler/lib/` — no matches.
+- `grep -rn "RangeFiles" compiler/lib/starlark_loader.go` — no matches (other `RangeFiles` callers elsewhere in the tree are untouched).
+- `gofmt -l` on all four changed/created files — no output (already formatted).
+
+## Known Issues (pre-existing, out of scope)
+
+- `go vet ./compiler/...` reports one pre-existing lock-copy finding in `compiler/lib/compiler.go:355`, present before this task and unrelated to `loadValidators`. Logged to `.planning/WINDOWS.md`.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+- Validator discovery is now filesystem-driven and ready for the planned lazy proto loading work (registry shrink from 864 to ~7 files) without silently dropping cross-field validators for protos the registry no longer eagerly loads.
+- The pre-existing `go vet` finding in `compiler.go:355` and the stale `load_remote_with_load_local.pconf` module pin remain open, unrelated cleanup candidates for future quick tasks.
+
+---
+*Quick task: 260904-f5j*
+*Completed: 2026-09-04*
+
+## Self-Check: PASSED
+
+- FOUND: compiler/lib/starlark_loader_test.go
+- FOUND: .planning/quick/260904-f5j-fix-loadvalidators-to-walk-the-filesyste/260904-f5j-SUMMARY.md
+- FOUND: commit 18cc828 in git log
+- FOUND: commit c8a6ff6 in git log
+- CONFIRMED: `grep -n "func stat(" compiler/lib/*.go` returns nothing

--- a/.planning/research/compiler-performance/BASELINE.md
+++ b/.planning/research/compiler-performance/BASELINE.md
@@ -1,0 +1,111 @@
+# Baseline: Compiler Startup Performance
+
+**Measured:** 2026-09-04
+**Corpus:** `~/go/src/github.com/protoconf/protoconf-terraform/example` — 799 `.proto` under `src/`, one `example.mpconf`
+**Machine:** darwin/arm64, warm page cache, `CGO_ENABLED` default
+**Binary:** `go build ./cmd/protoconf` at `823f546`
+
+## Headline
+
+`protoconf compile .` takes **6.97s**. The target is 200ms.
+
+Essentially all of it is startup. The actual compile is already inside budget.
+
+## Stage breakdown
+
+Measured by instrumenting the `NewCompiler` path directly (not `go test`, to avoid
+harness noise). Each stage timed in isolation on the corpus above:
+
+| Stage | Time | Share |
+|-------|------|-------|
+| `NewModuleService` + `LoadFromLockFile` | 0.03ms | ~0% |
+| `utils.NewDescriptorRegistry` (`desc.WrapFiles` over global registry) | 6.2ms | 0.1% |
+| **`ms.GetProtoRegistry()` — parse + link all 799 protos** | **4,639ms** | **94%** |
+| **`parser.NewParserWithDescriptorRegistry` — build resolvers over 864 files** | **260ms** | **5%** |
+| `protovalidate.New(legacy.WithLegacySupport(...))` | 2.7ms | 0.1% |
+| `c.CompileFile("example.mpconf")` — Starlark eval, validate, write | 197ms | — |
+
+`NewCompiler` = **5.06s**. `CompileFile` = **197ms**.
+
+**The compile step is already at the 200ms target.** The entire problem is that
+`NewCompiler` eagerly materializes the whole proto tree before any config is read.
+
+## What the config actually needs
+
+`src/example.mpconf` opens with six `load()` statements. Five name `.proto` files:
+
+```
+//terraform/random/provider/v3/random.proto
+//terraform/random/resources/v3/pet.proto
+//terraform/null/provider/v3/null.proto
+//terraform/null/datasources/v3/data.proto
+//protoconf_terraform/config/v1/config.proto
+```
+
+Parsing and linking exactly those five, plus their transitive imports:
+
+```
+parsed+linked 5 requested -> 7 total files in 2.686ms
+```
+
+**7 files needed. 864 loaded. 2.7ms vs 4,639ms — a ~1,700x gap.**
+
+This is the whole finding. The compiler's cost is not proportional to the config
+being compiled; it is proportional to the size of the repository the config
+happens to live in.
+
+## CPU profile
+
+`go tool pprof` over `GetProtoRegistry()` (5.15s wall, 7.57s samples across ~1.5 cores):
+
+| Node | cum | Notes |
+|------|-----|-------|
+| `runtime.gcDrain` | 2.80s (37%) | GC pressure |
+| `runtime.scanobject` | 2.59s (34%) | — |
+| `linker.Link` | 1.94s (26%) | of which `resolveReferences` 1.67s |
+| `linker.Files.FindFileByPath` | 1.18s (16%) | reached via `resolveInFile` -> `FindImportByPath` |
+| `runtime.madvise` | 1.10s (15%) | heap growth / return |
+| `parser.protoParserImpl.Parse` | 0.50s (7%) | — |
+
+Roughly: **~40% garbage collection, ~26% linking, ~7% parsing**, remainder
+allocation and I/O.
+
+The GC share is the tell. Materializing 864 fully-linked descriptor trees
+allocates enormously, and most of those objects are never read. Cutting the file
+count attacks the linking cost and the GC cost together — they are the same
+problem measured two ways.
+
+## Negative result: the linker lookup is not a fixable upstream bug
+
+`linker.Files.FindFileByPath` is a linear scan over a slice, and it shows up at
+16% of profile time. That looks like an O(n²) defect worth reporting upstream or
+patching around. It is not:
+
+- `(*result).FindImportByPath` calls `r.deps.FindFileByPath` — `r.deps` is **that
+  file's direct dependencies only**, typically a handful, not all 864.
+- The cost is therefore *call volume* (one lookup per symbol reference resolved
+  across 799 files), not scan length.
+- `protocompile` v0.14.1 has the identical implementation, byte for byte. A
+  dependency bump changes nothing here.
+
+Conclusion: there is no lookup to optimize. The only lever on linking cost is
+**linking fewer files**. Do not spend time on this path again.
+
+## Related measurements
+
+Numbers that constrain the design space (see OPTIONS.md):
+
+| Operation over all 799 protos | Time |
+|-------------------------------|------|
+| `ParseFilesButDoNotLink` (parse only, no linking) | 1,286ms |
+| Naive single-threaded lexical scan (read + 2 regexes/file) | 623ms |
+| Full parse + link (current behaviour) | 4,639ms |
+
+Both eager alternatives blow the 200ms budget on their own. **Any design that
+touches all 799 files on the hot path fails, regardless of how cheaply it
+touches them.**
+
+## Reproduction
+
+Harness scripts are inlined in TESTING.md. The corpus is a working tree, not a
+fixture — see TESTING.md for how to pin one.

--- a/.planning/research/compiler-performance/OPTIONS.md
+++ b/.planning/research/compiler-performance/OPTIONS.md
@@ -1,0 +1,121 @@
+# Options: Getting `NewCompiler` Under Budget
+
+Scope decision (2026-09-04): **lazy load-driven resolution**. This document
+records why, and what was rejected.
+
+## The shape of the fix
+
+Today `ModuleService.GetProtoRegistry()` eagerly walks `src/`, parses every
+`.proto`, links them all, and caches the result. `parser.ParseFilesX` — the
+function the Starlark loader calls when it hits `load("//x/y.proto", "Msg")` —
+is then a pure **map lookup** into that pre-filled registry. It never parses.
+
+```go
+// compiler/lib/parser/parser.go
+func (p *Parser) ParseFilesX(filenames ...string) ([]*desc.FileDescriptor, error) {
+    for _, filename := range filenames {
+        if fd, ok := p.FileDescriptors[filename]; ok { ... }   // pre-filled
+        fd, err := p.FilesResolver.FindFileByPath(filename)     // pre-filled
+        ...
+    }
+}
+```
+
+The inversion: make `ParseFilesX` parse on demand, and let `GetProtoRegistry()`
+return an empty-but-capable registry. The `load()` statements already name
+exactly the files needed, and `protoparse` already resolves transitive imports
+itself. The measured cost of that path is 2.7ms.
+
+The public shape of `ParseFilesX` does not change, which matters — see
+"Blast radius" below.
+
+## Option A — Lazy by path, on-demand parse (chosen)
+
+Parse and link a proto file the first time something asks for it by path,
+memoised in the existing `FileRegistry` map.
+
+- **Cost on the corpus:** 4,639ms -> ~3ms for registry construction.
+- **Knock-on:** `NewParserWithDescriptorRegistry` (260ms) is derived from
+  `FileRegistry` — `GetFilesResolver()` builds a `FileDescriptorSet` from every
+  entry and runs `protodesc.NewFiles` over it. With 7 entries instead of 864
+  that cost collapses proportionally. It cannot stay eager: a lazy registry with
+  an eager resolver snapshot would be a stale-cache bug the first time a new file
+  is parsed.
+- **Projected total:** ~200-210ms, dominated by the existing 197ms `CompileFile`.
+- **Risk:** lookups that are *not* by path. See PITFALLS.md — this is the real work.
+
+## Option B — Lazy + persisted linked-descriptor cache
+
+Option A plus an on-disk `FileDescriptorSet` cache keyed by content hash, so warm
+compiles skip parsing entirely.
+
+Deferred, not rejected. Rationale: Option A already lands at ~3ms for the load
+path. A cache optimises 3ms; it is not where the remaining budget is. The
+machinery also already half-exists (`registry.Store` / `registry.Load` write
+`.fds` files per module into `.protoconf_cache`), so this is cheap to add *later*
+if warm-start numbers ever justify it. Adding it now buys nothing measurable and
+introduces a cache-invalidation surface.
+
+Note it does become attractive if PITFALLS.md's symbol-index problem forces an
+index build — an index is exactly the kind of thing worth persisting.
+
+## Option C — Migrate off `jhump/protoreflect` to `protoregistry`/`dynamicpb`
+
+Rejected for this milestone. Already recorded in PROJECT.md as a deferred v2
+item ("large scope, touches compiler/starproto extensively"), and the profile
+does not implicate the `desc` wrappers: `desc.WrapFiles` over the global registry
+is 6.2ms, and `desc.wrapFile` is 0.16s cum inside a 4.6s stage. The cost is in
+`protocompile`'s parse+link, which both APIs sit on top of. Migrating would move
+the same work behind a different type.
+
+## Rejected: optimise the linker lookup
+
+`linker.Files.FindFileByPath` is 16% of profile time and is a linear scan. It is
+still not worth touching — `r.deps` is a per-file dependency list, not the full
+set, and v0.14.1 is byte-identical. See BASELINE.md "Negative result". Recorded
+here so it is not re-proposed.
+
+## Rejected: parallelise the eager parse
+
+Would divide 4.6s by core count at best — call it 600-800ms on an 8-core box,
+still 3-4x over budget, while burning every core on work that is ~99% discarded.
+It also makes GC pressure worse per unit of wall time, and the corpus that
+motivated this issue will keep growing. Parallelism is the wrong axis when the
+right answer is to not do the work.
+
+## Rejected: eager symbol index (any form)
+
+Needed to answer type-URL lookups (PITFALLS.md), but every eager variant measured
+over the corpus exceeds the whole budget by itself:
+
+| Variant | Cost |
+|---------|------|
+| `ParseFilesButDoNotLink` over 799 | 1,286ms |
+| Naive lexical scan (read + regex per file) | 623ms |
+
+Parallelising the lexical scan could plausibly reach ~100ms, but that spends half
+the total budget on an index most compiles never consult. If an index is
+required, it must be **persisted and incrementally maintained**, not rebuilt per
+invocation — which is Option B's machinery.
+
+## Blast radius
+
+`GetProtoRegistry()` has five consumers. All were checked; all are lookup-shaped,
+which is what makes lazy viable:
+
+| Consumer | Site | Lookup by |
+|----------|------|-----------|
+| compiler | `compiler/lib/compiler.go:65`, `:355` | path (`load()`), type URL |
+| mutation server | `server/server.go:290` | type URL |
+| inserter | `inserter/inserter.go:220` | type URL |
+| agent filekv | `agent/filekv/filekv.go:80` | type URL |
+| mutate CLI | `mutate/mutate.go:73` | type URL |
+
+The compiler is the only path-driven consumer, and the only one on the 200ms hot
+path. The other four resolve `google.protobuf.Any` type URLs — that is the case
+Option A does not answer on its own, and it is the subject of PITFALLS.md.
+
+One caller must stay eager: `ModuleService.Sync` / `GenFileDescriptorSet`
+(`protoconf mod sync`) genuinely needs to parse everything to write `.fds` cache
+files. That is a separate, explicitly-invoked command with no latency budget.
+Keep its eager path intact rather than routing it through the lazy one.

--- a/.planning/research/compiler-performance/PITFALLS.md
+++ b/.planning/research/compiler-performance/PITFALLS.md
@@ -1,0 +1,128 @@
+# Pitfalls: What Breaks Under Lazy Loading
+
+Lazy resolution is a **correctness change disguised as a performance change**.
+Today every proto in `src/` is in the registry, and several code paths quietly
+depend on that. Each one below is a silent-wrong-answer risk, not a crash.
+
+Ordered by how likely they are to ship undetected.
+
+## 1. `loadValidators` iterates the registry, not the filesystem — BLOCKER
+
+`compiler/lib/starlark_loader.go:116`:
+
+```go
+l.parser.FilesResolver.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+    protoFile := fd.Path()
+    validatorFile := protoFile + consts.ValidatorExtensionSuffix
+    validatorAbsPath := filepath.Join(l.srcDir, validatorFile)
+    if exists, isDir, err := stat(validatorAbsPath); ... 
+```
+
+For every proto in the registry, it stats for a sibling `.proto-validator` and
+loads it if present.
+
+Under lazy loading the registry holds 7 files instead of 864, so
+**cross-field validators attached to protos not reachable from `load()` are
+silently skipped.** Configs that should fail validation would compile clean. This
+is the worst possible failure mode for a config system: it does not error, it
+approves.
+
+It is also load-order dependent — `loadValidators` runs against whatever happens
+to be in the registry at that moment, which under lazy loading is a moving target.
+
+**Fix — and it is faster, not a compromise:** invert the loop. Walk the
+filesystem for `*.proto-validator` files and load those, instead of walking 864
+descriptors and stat-ing for each. Validators are rare (the terraform corpus has
+**zero**, yet still pays 864 stat syscalls today, inside the 197ms `CompileFile`).
+Walking a handful of real files is both correct under lazy loading and cheaper
+than what happens now.
+
+Do this **before** making the registry lazy. It is independently correct, it is a
+speedup on its own, and it removes the ordering hazard rather than working around it.
+
+## 2. `Any` resolution by type URL has no file to be lazy about
+
+Four of the five `GetProtoRegistry()` consumers (server, inserter, filekv, mutate)
+resolve `google.protobuf.Any` payloads through
+`MessageRegistry.FindMessageTypeByUrl` / `LocalResolver.FindMessageByURL`. The
+compiler does too, in `loadMutable` (`starlark_loader.go:173`, `:183`).
+
+A type URL is `type.googleapis.com/pkg.Message`. It names a **symbol**, not a
+file. Lazy-by-path cannot answer it: you cannot know which of 799 files declares
+`pkg.Message` without having looked inside them.
+
+This is the one genuinely hard part of the work. Options, in increasing cost:
+
+- **Convention:** derive a candidate path from the package name and probe it.
+  Cheap, works for repos where `pkg/v1/foo.proto` declares `pkg.v1.*`. Fails
+  silently on repos that do not follow it — so it needs a fallback, not a bare bet.
+- **Persisted symbol index:** build once, store in `.protoconf_cache`, invalidate
+  on mtime/hash. Correct and fast warm. Costs 623ms-1.29s to build cold (see
+  OPTIONS.md) and adds an invalidation surface.
+- **Eager fallback:** on a miss, fall back to today's full parse. Correct by
+  construction, and the slow path only fires when the fast path cannot answer.
+
+The pragmatic combination is convention-probe, then index, then eager fallback —
+but note that a *silent* fallback to eager parsing means a repo can regress to
+6.9s without anyone noticing. Whatever is built, **make the fallback loud** (a
+one-line warn, or a counter surfaced in `-v`), or the benchmark will pass while
+real users stay slow.
+
+Also worth checking: whether the mutation server and agent — which are long-lived
+processes, not CLI invocations — actually want lazy at all. Paying 4.6s once at
+daemon startup is very different from paying it per compile. Lazy may be correct
+to scope to the compiler and leave the daemons eager.
+
+## 3. `GetFilesResolver` / `GetTypesResolver` snapshot the registry
+
+`parser.NewParserWithDescriptorRegistry` calls `registry.GetFilesResolver()`,
+which builds a `FileDescriptorSet` from **every** entry in `FileRegistry` and runs
+`protodesc.NewFiles` over it, then `GetTypesResolver` ranges that to register
+every message and enum into a `protoregistry.Types`.
+
+These are eager snapshots taken once at construction. With a lazy registry, any
+file parsed *after* construction is absent from both resolvers — and
+`ParseFilesX` consults `p.FilesResolver.FindFileByPath` as its second lookup, so
+this is directly on the load path.
+
+The resolvers must become lazy views over the registry, or be invalidated on
+every insertion. A snapshot plus a lazy source is a stale-cache bug waiting to
+happen, and it will present as "works the first time, wrong the second".
+
+## 4. `registry.Store` writes whatever `localFiles` happens to hold
+
+`utils.go` `Store()` serialises `d.localFiles` to a `.fds` cache file, and
+`Parse()` resets `localFiles` on every call. Under lazy loading `localFiles`
+becomes "whatever was demanded so far" rather than "everything in this module",
+so a `mod sync` that shares a lazy registry would write a **truncated** cache file
+— which then loads clean and is wrong on the next run.
+
+Keep `mod sync` / `GenFileDescriptorSet` on the eager path (OPTIONS.md, "Blast
+radius"). Do not let the two share a registry instance.
+
+## 5. Import-cycle and error-surface changes
+
+`protoparse` reports import errors when it parses. Eagerly, a broken import
+anywhere in `src/` fails the compile immediately. Lazily, a broken proto that no
+config loads is never parsed and never reported.
+
+This is arguably an improvement — but it is a **behaviour change** that will
+surface as "CI used to catch this". Decide deliberately whether `protoconf
+compile` should keep validating the whole tree (perhaps behind a flag, or left to
+`mod sync`), and write it down rather than letting it change by accident.
+
+## 6. The benchmark corpus is a moving target
+
+`protoconf-terraform` is a working tree, not a fixture. Its proto count will
+drift, and every number in BASELINE.md drifts with it. See TESTING.md — pin a
+corpus before optimising against one, or the regression test measures the corpus
+rather than the compiler.
+
+## Ordering
+
+1. Fix `loadValidators` (item 1) — independently correct, independently faster.
+2. Pin a benchmark corpus (item 6) — nothing else is measurable without it.
+3. Make the resolvers lazy views (item 3) — prerequisite for a lazy registry.
+4. Lazy-by-path registry — the actual win.
+5. Type-URL resolution (item 2) — the hard part; scope may reduce to compiler-only.
+6. Decide and document the error-surface change (item 5).

--- a/.planning/research/compiler-performance/SUMMARY.md
+++ b/.planning/research/compiler-performance/SUMMARY.md
@@ -1,0 +1,117 @@
+# Compiler Performance Research — Summary
+
+**Date:** 2026-09-04 · **Corpus:** protoconf-terraform (799 protos) · **Target:** 200ms
+
+## The finding in one line
+
+`protoconf compile` costs 6.97s, of which **5.06s is `NewCompiler` eagerly
+parsing and linking all 799 protos** — while the config being compiled loads
+exactly 5 of them, 7 with transitive imports.
+
+The actual compile step (`CompileFile`) is already **197ms**. It is at target.
+There is nothing to optimise there.
+
+| | Now | Needed | Measured achievable |
+|---|---|---|---|
+| Registry construction | 4,639ms | — | **2.7ms** (parse+link the 7 real files) |
+| Resolver construction | 260ms | — | proportional — collapses with the registry |
+| CompileFile | 197ms | ≤200ms | already fine |
+| **Total** | **6.97s** | **200ms** | **~210ms** |
+
+The 200ms goal is reachable, and the headroom is comfortable — the fix removes
+~4.9s and the remainder is already inside budget.
+
+## Why it is slow
+
+Cost is proportional to **repository size**, not to the config being compiled.
+`GetProtoRegistry()` walks `src/`, parses everything, links everything, and caches
+it; `ParseFilesX` — the function that services `load("//x/y.proto", ...)` — is then
+a pure map lookup that never parses. The work is done up front on the assumption
+that all of it will be needed. On this corpus ~99% is discarded.
+
+Profile: ~40% garbage collection (materializing 864 descriptor trees), ~26%
+linking, ~7% parsing. The GC share and the linking share are the same problem
+counted twice — cutting the file count attacks both.
+
+## Two things that look like leads and are not
+
+Recorded so they are not re-investigated:
+
+- **`linker.Files.FindFileByPath` is 16% of profile time and is a linear scan** —
+  but it scans a file's *direct deps*, not all 864. The cost is call volume,
+  inherent to linking 799 files. `protocompile` v0.14.1 is byte-identical, so a
+  dependency bump changes nothing. There is no lookup to fix; only files not to link.
+- **Parallelising the eager parse** — divides 4.6s by core count at best, still
+  3-4x over budget, and burns every core on ~99% discarded work.
+
+## Recommendation
+
+**Lazy, load-driven resolution.** Parse a proto the first time it is asked for by
+path; the `load()` statements already name exactly what is needed and `protoparse`
+resolves transitive imports itself. Measured cost of that path: 2.7ms.
+
+Deferred deliberately: an on-disk descriptor cache (optimises 3ms — not where the
+budget is, and the `.fds` machinery already half-exists if warm-start ever
+justifies it), and the `jhump/protoreflect` → `dynamicpb` migration (already a
+recorded v2 item, and the profile does not implicate the wrappers).
+
+## The real work is correctness, not speed
+
+The speedup is close to free. **Lazy loading is a correctness change disguised as
+a performance change**, and every risk it carries is a silent-wrong-answer risk:
+
+1. **`loadValidators` walks the registry, not the filesystem** — with 7 files in
+   the registry instead of 864, validators on protos not reachable from `load()`
+   are silently skipped. Configs that should fail would compile clean. This is a
+   blocker, and the fix (walk the filesystem for `*.proto-validator` instead) is
+   *also faster* — the terraform corpus has zero validators and still pays 864
+   stat syscalls today. **Do this first, on its own merits.**
+2. **`Any` resolution is by type URL, not path** — a symbol, not a file. Lazy-by-path
+   cannot answer it, and four of the five registry consumers (server, inserter,
+   agent, mutate) depend on it. This is the genuinely hard part. Any eager index
+   blows the budget alone (623ms lexical scan, 1.29s parse-only), so it needs a
+   persisted index or a *loud* eager fallback — a silent one lets a repo regress
+   to 6.9s unnoticed. Scoping lazy to the compiler and leaving the long-lived
+   daemons eager is a legitimate simplification worth considering.
+3. **The resolvers are eager snapshots** of the registry, taken at construction
+   and consulted on the load path. Against a lazy registry that is a stale-cache
+   bug — "works the first time, wrong the second".
+4. **`mod sync` must stay eager** — it serialises the registry to `.fds` cache
+   files, and a lazy registry would write a truncated cache that then loads clean
+   and is wrong.
+
+## Testing
+
+No compiler performance coverage exists today. Two gaps:
+
+- **Pin a corpus.** Every number here came from a live working tree. Generate
+  synthetic protos parameterised on N instead — the property worth asserting is
+  *scaling*, and only a generator lets you assert it.
+- **Assert the ratio, not the milliseconds.** "Compiling a 5-proto config costs the
+  same at N=50 and N=5000" is machine-independent and fails loudly if an eager walk
+  returns. An absolute 200ms gate on a CI runner will flake, get bumped, and become
+  worthless. Track `allocs/op` too — with 40% of time in GC it moves first and is
+  less noisy than `ns/op`.
+
+Speed tests catch none of the four correctness risks. Each needs its own test that
+fails before the fix — the validator one (a `.proto-validator` on a proto no config
+loads) is the highest-value test in the set.
+
+## Suggested order
+
+1. Fix `loadValidators` — independently correct, independently faster, removes an
+   ordering hazard rather than working around it.
+2. Pin a benchmark corpus — nothing else is measurable without it.
+3. Make the resolvers lazy views — prerequisite for a lazy registry.
+4. Lazy-by-path registry — the actual win (~4.9s).
+5. Type-URL resolution — the hard part; scope may reduce to compiler-only.
+6. Decide and document the error-surface change (a broken proto no config loads is
+   no longer reported at compile time — arguably better, but it is a behaviour
+   change that will surface as "CI used to catch this").
+
+## Documents
+
+- `BASELINE.md` — measurements, stage table, profile, reproduction
+- `OPTIONS.md` — approaches considered, rejected paths with reasons, blast radius
+- `PITFALLS.md` — the four correctness risks in detail, with fixes
+- `TESTING.md` — corpus strategy, benchmark shape, correctness guards, CI posture

--- a/.planning/research/compiler-performance/TESTING.md
+++ b/.planning/research/compiler-performance/TESTING.md
@@ -1,0 +1,126 @@
+# Testing: How to Measure and How to Not Regress
+
+The repo has exactly one benchmark today (`agent/kv_agent_impl_test.go`) and no
+compiler performance coverage at all. That is the first gap to close — a
+performance change with no regression test decays back to 6.9s within a year.
+
+## Pin a corpus first
+
+Every number in BASELINE.md came from `protoconf-terraform/example`, which is a
+live working tree. Its proto count will drift, and the measurement drifts with it.
+A benchmark against an unpinned corpus measures the corpus.
+
+Options, cheapest first:
+
+- **Generate it.** A `testdata` generator that emits N synthetic protos with a
+  configurable import fan-out. Deterministic, versioned with the code, and lets
+  the benchmark parameterise on N — which is the property that actually matters
+  here, since the bug is "cost scales with repo size, not config size". Recommended.
+- **Vendor a slice.** Copy a fixed subset of the terraform protos into `testdata/`.
+  Realistic shapes, but bulky in-repo and still a snapshot.
+- **Submodule / fetch-on-demand.** Faithful, but makes the benchmark
+  network-dependent and CI-fragile. Not worth it.
+
+The generator is the right call: the assertion worth making is *scaling*, and only
+a generator lets you assert it.
+
+## The assertion that matters
+
+Absolute wall-clock in CI is noisy and machine-dependent — a 200ms threshold on a
+shared runner will flake. The defensible assertion is **scaling behaviour**:
+
+> Compiling a config that loads 5 protos costs the same whether the repo contains
+> 50 protos or 5,000.
+
+Concretely: run the compile at N=50 and N=5000 and assert the ratio stays under a
+small constant (say 2x). That is exactly the property being fixed, it is robust to
+machine speed, and it fails loudly if anyone reintroduces an eager walk.
+
+Keep a wall-clock benchmark too, but as a **reported number, not a gate** — same
+posture the project already took with codecov thresholds (quick task 260902-cov).
+
+## Benchmark shape
+
+```go
+func BenchmarkCompilerStartup(b *testing.B) {
+    for _, n := range []int{50, 500, 5000} {
+        b.Run(fmt.Sprintf("protos=%d", n), func(b *testing.B) {
+            root := generateCorpus(b, n)   // b.TempDir(), N protos, config loads 5
+            b.ResetTimer()
+            for i := 0; i < b.N; i++ {
+                c, err := lib.NewCompiler(root, false)
+                if err != nil { b.Fatal(err) }
+                if err := c.CompileFile("main.mpconf"); err != nil { b.Fatal(err) }
+            }
+        })
+    }
+}
+```
+
+Run with `-benchmem`. Allocation count is the leading indicator here — the profile
+showed ~40% of time in GC, so `allocs/op` will move before `ns/op` does and is far
+less noisy. Track it.
+
+## Stage-level instrumentation
+
+The stage table in BASELINE.md was produced by timing each constructor
+independently. Worth keeping as a throwaway harness rather than shipped code:
+
+```go
+t := time.Now(); ms, _ := lib.NewModuleService(root); ms.LoadFromLockFile()
+fmt.Println("NewModuleService+lock:", time.Since(t))
+
+t = time.Now(); reg := ms.GetProtoRegistry()
+fmt.Println("GetProtoRegistry:", time.Since(t), "files:", len(reg.FileRegistry))
+
+t = time.Now(); _ = parser.NewParserWithDescriptorRegistry(reg)
+fmt.Println("NewParserWithDescriptorRegistry:", time.Since(t))
+```
+
+`NewCompiler` already logs `slog.Info("module service loaded", "took", ...)`
+(`compiler/lib/compiler.go:66`). Extending that one line to also report the file
+count would make the problem visible in the field without any harness at all —
+"loaded 864 files in 4.6s" is self-evidently wrong to anyone reading it.
+
+## Profiling recipe
+
+```go
+f, _ := os.Create("cpu.out")
+pprof.StartCPUProfile(f); defer pprof.StopCPUProfile()
+// ... construct compiler, compile ...
+```
+
+```
+go tool pprof -top -nodecount=25 cpu.out
+go tool pprof -peek='FindImportByPath|linker.Link' cpu.out
+```
+
+`-peek` is what separated "linear scan over 864" from "many short scans" and
+killed the upstream-bug theory (BASELINE.md, "Negative result"). Reach for it
+before drawing conclusions from a flat `-top`.
+
+Add `-memprofile` alongside. Given the GC share, the allocation profile is
+probably more actionable than the CPU one for the remaining work.
+
+## Correctness guards — the part that actually matters
+
+The pitfalls in PITFALLS.md are all silent-wrong-answer risks. Speed tests will
+not catch any of them. Each needs a test that fails *before* the fix:
+
+| Guard | Test |
+|-------|------|
+| Validators still fire (PITFALLS 1) | Corpus where a `.proto-validator` sits on a proto **not** reachable from `load()`. Assert the compile fails. This is the highest-value test in the set — it fails today's design the moment the registry goes lazy. |
+| `Any` round-trip (PITFALLS 2) | Materialize a config with an `Any` payload whose type is not in any `load()`; assert inserter/agent still resolve it. |
+| No silent eager fallback (PITFALLS 2) | Assert the eager path is not taken on the happy path — count parsed files and assert it stays small. Otherwise a fallback masks the regression. |
+| Resolver freshness (PITFALLS 3) | Load proto A, then proto B, then look A up again through `FilesResolver`. Catches the stale-snapshot bug. |
+| `mod sync` completeness (PITFALLS 4) | Run `mod sync`, assert the written `.fds` contains every proto in the module, not just demanded ones. |
+
+## CI
+
+`go.yml` already runs tests with Codecov. Add the benchmark as a **separate
+non-blocking job** that reports numbers; gate only on the scaling-ratio assertion,
+which belongs in the normal test suite as an ordinary `go test` (it is a ratio, so
+it is machine-independent).
+
+Do not gate CI on absolute milliseconds. It will flake, someone will bump the
+threshold to make it green, and the gate will be worthless.

--- a/compiler/lib/filesystem.go
+++ b/compiler/lib/filesystem.go
@@ -12,17 +12,6 @@ func mkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 
-func stat(path string) (bool, bool, error) {
-	pathStat, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, false, nil
-		}
-		return false, false, err
-	}
-	return true, pathStat.IsDir(), nil
-}
-
 func openFile(path string) (io.ReadCloser, error) {
 	return os.Open(path)
 }

--- a/compiler/lib/filesystem_js.go
+++ b/compiler/lib/filesystem_js.go
@@ -13,11 +13,6 @@ func mkdirAll(path string, perm os.FileMode) error {
 	return nil
 }
 
-func stat(path string) (bool, bool, error) {
-	contents := js.Global().Call("readFile", path)
-	return !contents.IsNull(), false, nil
-}
-
 func openFile(path string) (io.ReadCloser, error) {
 	contents := js.Global().Call("readFile", path)
 	if contents.IsNull() {

--- a/compiler/lib/starlark_loader.go
+++ b/compiler/lib/starlark_loader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/qri-io/starlib"
 	"go.starlark.net/starlark"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
@@ -112,32 +112,36 @@ func (l *starlarkLoader) Load(thread *starlark.Thread, moduleName string) (starl
 func (l *starlarkLoader) loadValidators() (map[string]*starlark.Function, error) {
 	validators := make(map[string]*starlark.Function)
 	l.Modules["add_validator"] = starlark.NewBuiltin("add_validator", starAddValidator(&validators))
-	var walkErr error
-	l.parser.FilesResolver.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
-		protoFile := fd.Path()
-		validatorFile := protoFile + consts.ValidatorExtensionSuffix
-		validatorAbsPath := filepath.Join(l.srcDir, validatorFile)
-		if exists, isDir, err := stat(validatorAbsPath); err != nil {
-			walkErr = fmt.Errorf("error getting file stat for validator %s: %w", validatorAbsPath, err)
-			return false
-		} else if isDir {
-			walkErr = fmt.Errorf("expected validator file, got directory: %s", validatorAbsPath)
-			return false
-		} else if !exists {
-			return true
+	validatorSuffix := consts.ProtoExtension + consts.ValidatorExtensionSuffix
+	err := filepath.WalkDir(l.srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return err
 		}
+		if !strings.HasSuffix(path, validatorSuffix) {
+			return nil
+		}
+		if d.IsDir() {
+			return fmt.Errorf("expected validator file, got directory: %s", path)
+		}
+		rel, err := filepath.Rel(l.srcDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
 		thread := &starlark.Thread{
 			Print: starPrint,
 			Load:  l.Load,
 		}
-		if _, err := l.Load(thread, filepath.ToSlash(validatorFile)); err != nil {
-			walkErr = fmt.Errorf("error loading validator %s: %w", validatorFile, err)
-			return false
+		if _, err := l.Load(thread, rel); err != nil {
+			return fmt.Errorf("error loading validator %s: %w", rel, err)
 		}
-		return true
+		return nil
 	})
-	if walkErr != nil {
-		return nil, walkErr
+	if err != nil {
+		return nil, err
 	}
 	return validators, nil
 }

--- a/compiler/lib/starlark_loader_test.go
+++ b/compiler/lib/starlark_loader_test.go
@@ -1,0 +1,75 @@
+package lib
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/bufbuild/protovalidate-go"
+	_ "github.com/bufbuild/protovalidate-go/legacy"
+	_ "github.com/protoconf/protoconf/pb/protoconf/v1"
+
+	"github.com/protoconf/protoconf/utils/testdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupValidatorTestDir mirrors TestCompiler_CompileFile's opening sequence
+// (SmallTestDir, NewModuleService, Init, Sync) so fixtures written into the
+// returned dir before NewCompiler is called are picked up identically to how
+// the compiler test suite exercises this package.
+func setupValidatorTestDir(t *testing.T) string {
+	t.Helper()
+	dir := testdata.SmallTestDir()
+
+	ms, err := NewModuleService(dir)
+	require.NoError(t, err)
+	require.NoError(t, ms.Init(context.Background(), "CONFIGSPACE"))
+	require.NoError(t, ms.Sync(context.Background()))
+
+	return dir
+}
+
+func TestLoadValidators_OrphanValidatorIsDiscovered(t *testing.T) {
+	dir := setupValidatorTestDir(t)
+
+	// no_such_proto.proto does not exist anywhere in this fixture, so this
+	// validator is unreachable through the descriptor registry under any
+	// loading strategy. It must be found by walking the filesystem instead.
+	//
+	// Named with a "zz_" prefix so it sorts lexically after the fixture's
+	// pre-existing src/test.proto-validator: both files register a
+	// validator for the same ValidateMe message, and add_validator's map
+	// keeps only the most recently registered function per message
+	// (starlark_functions.go). Walk order is now deterministic (that is
+	// this task's whole point), so putting this fixture last guarantees
+	// its always-failing rule is the one actually enforced, rather than
+	// being silently overwritten by test.proto-validator's own validators.
+	orphan := `load("//test.proto", "ValidateMe")
+
+def always_fails_validator(v):
+    fail("always fails")
+
+add_validator(ValidateMe, always_fails_validator)
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src", "zz_no_such_proto.proto-validator"), []byte(orphan), 0644))
+
+	c, err := NewCompiler(dir, false)
+	require.NoError(t, err)
+
+	err = c.CompileFile("validator_passing_test.pconf")
+	assert.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestLoadValidators_DirectoryShapedLikeValidator(t *testing.T) {
+	dir := setupValidatorTestDir(t)
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "src", "oops.proto-validator"), 0755))
+
+	c, err := NewCompiler(dir, false)
+	require.NoError(t, err)
+
+	err = c.CompileFile("test.pconf")
+	assert.ErrorContains(t, err, "expected validator file, got directory")
+}


### PR DESCRIPTION
- **docs: research compiler startup performance (6.9s -> 200ms target)**
- **feat(quick-260904-f5j): walk srcDir for validator files instead of ranging registry**
- **test(quick-260904-f5j): regression test for filesystem-driven validator discovery**
- **docs(quick-260904-f5j): loadValidators walks srcDir instead of the descriptor registry**
